### PR TITLE
Refactored document retrieval per case, documents can now be received…

### DIFF
--- a/Modules/feature-common/Sources/UI/Request/Model/RequestDataUIModel.swift
+++ b/Modules/feature-common/Sources/UI/Request/Model/RequestDataUIModel.swift
@@ -198,7 +198,11 @@ extension RequestDataUiModel {
 
     for docElement in docElements {
 
-      for storageDocument in walletKitController.fetchDocuments(with: docElement.docType) {
+      let storageDocuments = walletKitController.fetchDocuments(
+        with: .init(rawValue: docElement.docType)
+      )
+
+      for storageDocument in storageDocuments {
 
         // Filter fields for Selectable Disclosed Fields
         let dataFields = documentSelectiveDisclosableFields(

--- a/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
@@ -7101,11 +7101,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -7114,6 +7114,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -7360,11 +7400,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -7550,11 +7612,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -7730,8 +7816,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/feature-dashboard/Sources/Interactor/DashboardInteractor.swift
+++ b/Modules/feature-dashboard/Sources/Interactor/DashboardInteractor.swift
@@ -78,8 +78,9 @@ final class DashboardInteractorImpl: DashboardInteractor {
   }
 
   private func fetchBearer() -> BearerUIModel {
-    let documents = self.walletController.fetchDocuments()
-    return documents.transformToBearerUi()
+    return BearerUIModel.transformToBearerUi(
+      walletKitController: self.walletController
+    )
   }
 
   private func fetchDocuments() -> [DocumentUIModel]? {

--- a/Modules/feature-dashboard/Sources/UI/Dashboard/Model/BearerUIModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Dashboard/Model/BearerUIModel.swift
@@ -35,8 +35,11 @@ public struct BearerUIModel: Identifiable, Equatable {
 public extension BearerUIModel {
 
   struct Value: Equatable {
+
     public let name: String
-    public let image: Image
+
+    @EquatableNoop
+    public var image: Image
   }
 
   static func mock() -> BearerUIModel {
@@ -48,18 +51,19 @@ public extension BearerUIModel {
       )
     )
   }
-}
 
-extension Array where Element == MdocDecodable {
-  func transformToBearerUi() -> BearerUIModel {
+  static func transformToBearerUi(
+    walletKitController: WalletKitController
+  ) -> BearerUIModel {
 
+    let storageDocuments = walletKitController.fetchDocuments(
+      excluded: [DocumentTypeIdentifier.EuPidDocType]
+    )
+
+    var name = walletKitController.fetchMainPidDocument()?.getBearersName()?.first
     var image: Image?
 
-    var name = self
-      .filter({ $0.docType == DocumentTypeIdentifier.EuPidDocType.rawValue })
-      .sorted { $0.createdAt > $1.createdAt }.last?.getBearersName()?.first
-
-    for item in self {
+    for item in storageDocuments {
 
       guard name == nil || image == nil else {
         break

--- a/Modules/feature-dashboard/Tests/Interactor/TestDashboardInteractor.swift
+++ b/Modules/feature-dashboard/Tests/Interactor/TestDashboardInteractor.swift
@@ -80,6 +80,8 @@ final class TestDashboardInteractor: EudiTest {
   func testFetchDashboard_WhenWalletKitControllerReturnsEmpty_ThenReturnError() async {
     // Given
     stubFetchDocuments(with: [])
+    stubFetchDocumentsWithExclusion(with: [])
+    stubFetchMainPidDocument(with: nil)
     // When
     let state = await interactor.fetchDashboard()
     // Then
@@ -104,6 +106,17 @@ final class TestDashboardInteractor: EudiTest {
           expiresAt: "30 Mar 2050",
           hasExpired: false
         )
+      ),
+      .init(
+        id: Constants.randomIdentifier,
+        value: .init(
+          id: Constants.isoMdlModelId,
+          type: DocumentTypeIdentifier.IsoMdlModel.rawValue,
+          title: "Driving License",
+          createdAt: Constants.documentCreatedAt,
+          expiresAt: "30 Mar 2050",
+          hasExpired: false
+        )
       )
     ]
     let expectedBearer: BearerUIModel = .init(
@@ -113,7 +126,9 @@ final class TestDashboardInteractor: EudiTest {
         image: Theme.shared.image.user
       )
     )
-    stubFetchDocuments(with: [Constants.euPidModel])
+    stubFetchDocuments(with: [Constants.euPidModel, Constants.isoMdlModel])
+    stubFetchDocumentsWithExclusion(with: [Constants.isoMdlModel])
+    stubFetchMainPidDocument(with: Constants.euPidModel)
     // When
     let state = await interactor.fetchDashboard()
     // Then
@@ -143,6 +158,18 @@ private extension TestDashboardInteractor {
   func stubFetchDocuments(with documents: [MdocDecodable]) {
     stub(walletKitController) { mock in
       when(mock).fetchDocuments().thenReturn(documents)
+    }
+  }
+  
+  func stubFetchDocumentsWithExclusion(with documents: [MdocDecodable]) {
+    stub(walletKitController) { mock in
+      when(mock).fetchDocuments(excluded: any()).thenReturn(documents)
+    }
+  }
+  
+  func stubFetchMainPidDocument(with document: MdocDecodable?) {
+    stub(walletKitController) { mock in
+      when(mock).fetchMainPidDocument().thenReturn(document)
     }
   }
 }

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -7513,11 +7513,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -7526,6 +7526,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -7772,11 +7812,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -7962,11 +8024,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -8142,8 +8228,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/feature-issuance/Sources/Interactor/DocumentDetailsInteractor.swift
+++ b/Modules/feature-issuance/Sources/Interactor/DocumentDetailsInteractor.swift
@@ -49,12 +49,14 @@ final class DocumentDetailsInteractorImpl: DocumentDetailsInteractor {
       var shouldDeleteAllDocuments: Bool {
         if type == .EuPidDocType {
 
-          let documentPids = walletController.fetchDocuments()
-            .filter({ $0.docType == DocumentTypeIdentifier.EuPidDocType.rawValue })
+          let documentPids = walletController.fetchDocuments(
+            with: DocumentTypeIdentifier.EuPidDocType
+          )
+          let mainPid = walletController.fetchMainPidDocument()
 
           guard documentPids.count > 1 else { return true }
 
-          return documentPids.sorted { $0.createdAt > $1.createdAt }.last?.id == documentId
+          return mainPid?.id == documentId
 
         } else {
           return false

--- a/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
@@ -7833,11 +7833,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -7846,6 +7846,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -8092,11 +8132,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -8282,11 +8344,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -8462,8 +8548,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/feature-login/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-login/Tests/Mock/GeneratedMocks.swift
@@ -7387,11 +7387,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -7400,6 +7400,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -7646,11 +7686,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -7836,11 +7898,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -8016,8 +8102,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -7439,11 +7439,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -7452,6 +7452,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -7698,11 +7738,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -7888,11 +7950,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -8068,8 +8154,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
@@ -7673,11 +7673,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -7686,6 +7686,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -7932,11 +7972,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -8122,11 +8184,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -8302,8 +8388,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
@@ -7276,11 +7276,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -7289,6 +7289,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -7535,11 +7575,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -7725,11 +7787,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -7905,8 +7991,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/logic-api/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-api/Tests/Mock/GeneratedMocks.swift
@@ -4834,11 +4834,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -4847,6 +4847,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -5093,11 +5133,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -5283,11 +5345,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -5463,8 +5549,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
@@ -5208,11 +5208,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -5221,6 +5221,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -5467,11 +5507,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -5657,11 +5719,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -5837,8 +5923,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     

--- a/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
@@ -4143,11 +4143,11 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable] {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable] {
         
     return cuckoo_manager.call(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
     """,
             parameters: (type),
             escapingParameters: (type),
@@ -4156,6 +4156,46 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
             defaultCall: __defaultImplStub!.fetchDocuments(with: type))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable] {
+        
+    return cuckoo_manager.call(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """,
+            parameters: (excluded),
+            escapingParameters: (excluded),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchDocuments(excluded: excluded))
+        
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable? {
+        
+    return cuckoo_manager.call(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
+    """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.fetchMainPidDocument())
         
     }
     
@@ -4402,11 +4442,33 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.ProtocolStubFunction<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.ProtocolStubFunction<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func fetchMainPidDocument() -> Cuckoo.ProtocolStubFunction<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self, method:
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, parameterMatchers: matchers))
         }
         
@@ -4592,11 +4654,35 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock {
         
         
         @discardableResult
-        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(String), [MdocDecodable]> where M1.MatchedType == String {
-            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: type) { $0 }]
+        func fetchDocuments<M1: Cuckoo.Matchable>(with type: M1) -> Cuckoo.__DoNotUse<(DocumentTypeIdentifier), [MdocDecodable]> where M1.MatchedType == DocumentTypeIdentifier {
+            let matchers: [Cuckoo.ParameterMatcher<(DocumentTypeIdentifier)>] = [wrap(matchable: type) { $0 }]
             return cuckoo_manager.verify(
     """
-    fetchDocuments(with: String) -> [MdocDecodable]
+    fetchDocuments(with: DocumentTypeIdentifier) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchDocuments<M1: Cuckoo.Matchable>(excluded: M1) -> Cuckoo.__DoNotUse<([DocumentTypeIdentifier]), [MdocDecodable]> where M1.MatchedType == [DocumentTypeIdentifier] {
+            let matchers: [Cuckoo.ParameterMatcher<([DocumentTypeIdentifier])>] = [wrap(matchable: excluded) { $0 }]
+            return cuckoo_manager.verify(
+    """
+    fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func fetchMainPidDocument() -> Cuckoo.__DoNotUse<(), MdocDecodable?> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+    """
+    fetchMainPidDocument() -> MdocDecodable?
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -4772,8 +4858,24 @@ public class WalletKitControllerStub: WalletKitController {
     
     
     
-    public func fetchDocuments(with type: String) -> [MdocDecodable]  {
+    public func fetchDocuments(with type: DocumentTypeIdentifier) -> [MdocDecodable]  {
         return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchDocuments(excluded: [DocumentTypeIdentifier]) -> [MdocDecodable]  {
+        return DefaultValueRegistry.defaultValue(for: ([MdocDecodable]).self)
+    }
+    
+    
+    
+    
+    
+    public func fetchMainPidDocument() -> MdocDecodable?  {
+        return DefaultValueRegistry.defaultValue(for: (MdocDecodable?).self)
     }
     
     


### PR DESCRIPTION
… with docType exclusion list, the mainPid retrieval logic is now part of the WalletKitController, transformers and unit tests adjustments.

# Description of changes

Please include a summary of the change and what is fixed or updated. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable