### PR TITLE
feat: add No Transactions empty state to transaction tab

### DIFF
--- a/Modules/feature-dashboard/Sources/UI/Dashboard/DashboardView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Dashboard/DashboardView.swift
@@ -262,6 +262,7 @@ private func content(
           systemImage: "arrow.left.arrow.right"
         )
       }
+      .tag(SelectedTab.transactions)
   }
 }
 

--- a/Modules/feature-dashboard/Sources/UI/Dashboard/Tab/TransactionTabView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Dashboard/Tab/TransactionTabView.swift
@@ -14,11 +14,36 @@
  * governing permissions and limitations under the Licence.
  */
 import SwiftUI
+import logic_ui
+import logic_resources
 
 public struct TransactionTabView: View {
-  public var body: some View {
-    Text("Transactions")
-  }
+    public var body: some View {
+      contentUnavailableView()
+    }
+    
+    @ViewBuilder
+    private func contentUnavailableView() -> some View {
+        VStack(spacing: SPACING_SMALL) {
+            Theme.shared.image.clockIndicator
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 48, height: 48)
+                .foregroundStyle(Theme.shared.color.onSurfaceVariant)
+                .padding(.bottom, SPACING_SMALL)
+            
+            Text(.noTransactions)
+                .typography(Theme.shared.font.titleLarge)
+                .fontWeight(.bold)
+            
+            Text(.noTransactionsDescription)
+                .typography(Theme.shared.font.bodyLarge)
+                .foregroundStyle(Theme.shared.color.onSurface)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.horizontal, SPACING_MEDIUM)
+    }
 }
 
 #Preview {

--- a/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
+++ b/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
@@ -183,6 +183,8 @@ public enum LocalizableStringKey: Equatable, Sendable {
   case walletIsSecured
   case noResults
   case noResultsDescription
+  case noTransactions
+  case noTransactionsDescription
   case proximityConnectionNfcDescription
   case orShareViaNfc
   case expiryPeriodSectionTitle

--- a/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
+++ b/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
@@ -349,6 +349,10 @@ final class LocalizableManager: LocalizableManagerType {
       bundle.localizedString(forKey: "no_results")
     case .noResultsDescription:
       bundle.localizedString(forKey: "no_results_description")
+    case .noTransactions:
+      bundle.localizedString(forKey: "no_transactions")
+    case .noTransactionsDescription:
+      bundle.localizedString(forKey: "no_transactions_description")
     case .proximityConnectionNfcDescription:
       bundle.localizedString(forKey: "proximity_connection_nfc_description")
     case .orShareViaNfc:

--- a/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
+++ b/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
@@ -1159,6 +1159,28 @@
         }
       }
     },
+    "no_transactions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Transactions"
+          }
+        }
+      }
+    },
+    "no_transactions_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your transaction history will appear here after you use your identity documents."
+          }
+        }
+      }
+    },
     "ok_button" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
# Description of changes
Related to #252

This PR implements a new empty state for the Transaction tab when no transaction history is available. The changes include:

- Created dedicated Transaction tab UI with empty state messaging
- Added transaction-specific localization keys (`noTransactions` and `noTransactionsDescription`) 
- Implemented a clean UI displaying an icon, title, and helpful description text
- Updated localization manager to support the new transaction-specific keys

The empty state provides clear feedback to users when they have no transaction history yet, explaining that transactions will appear after they use their identity documents.

<p align="center">
  <img src="https://github.com/user-attachments/assets/846e0547-1422-4299-9884-e56d619bc274" width="25%">
</p>

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked that my strings are *localized* where applicable