### PR TITLE
Refactor : Batch issuance rework

### DIFF
--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6cb85bbb13dee2ce207651c52fccfd5f8c32bb90650b90af0efdeb35cd3cb608",
+  "originHash" : "9e3542761594ffb611b01b8c877694d8bf39b08bcb4f696b5b29fc6a997bf926",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "5a26035bcf96f7aad2855e10fc35f109fde2d151",
-        "version" : "0.7.3"
+        "revision" : "2eabc58231614e6a509053c8411239b1cd47244a",
+        "version" : "0.7.5"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "4db02899e6a52affd33296440c5d766f6889d690",
-        "version" : "0.7.3"
+        "revision" : "277e3a80014e8c2acf47a1a9e076d98610080b70",
+        "version" : "0.7.5"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "2f21c70295ed1569963f5eb7f4a45f3c4ec0b9ba",
-        "version" : "0.6.4"
+        "revision" : "c8db844ce7d3330c3096b3794fb1a1ae9d2dbaa0",
+        "version" : "0.6.5"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "c4bd0181ce27a9b22bf271bb3f89933f0355c608",
-        "version" : "0.15.2"
+        "revision" : "508556bdd1cf517735a0e6405c9dbd2704e6a892",
+        "version" : "0.15.4"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "317fc0987cb68564888f626bd155229821114ebd",
-        "version" : "0.13.4"
+        "revision" : "c48a518a800203d9628b898fcd7350eca2fcacb6",
+        "version" : "0.13.5"
       }
     },
     {

--- a/Modules/feature-common/Sources/Config/Issuance/IssuanceFlowUiConfig.swift
+++ b/Modules/feature-common/Sources/Config/Issuance/IssuanceFlowUiConfig.swift
@@ -14,21 +14,33 @@
  * governing permissions and limitations under the Licence.
  */
 import logic_ui
+import logic_core
 
 public struct IssuanceFlowUiConfig: UIConfigType, Equatable {
 
   public let flow: Flow
 
   public var log: String {
-    return "flow: \(flow.rawValue)"
+    switch flow {
+    case .noDocument:
+      return "flow: noDocument"
+    case .extraDocument(let identifier):
+      return "flow: extraDocument(\(identifier?.rawValue ?? ""))"
+    }
   }
 
   public var isNoDocumentFlow: Bool {
-    self.flow == .noDocument
+    if case .noDocument = flow {
+      return true
+    }
+    return false
   }
 
   public var isExtraDocumentFlow: Bool {
-    self.flow == .extraDocument
+    if case .extraDocument = flow {
+      return true
+    }
+    return false
   }
 
   public init(flow: Flow) {
@@ -37,8 +49,8 @@ public struct IssuanceFlowUiConfig: UIConfigType, Equatable {
 }
 
 public extension IssuanceFlowUiConfig {
-  enum Flow: String, Equatable, Sendable {
+  enum Flow: Equatable, Sendable {
     case noDocument
-    case extraDocument
+    case extraDocument(DocumentTypeIdentifier?)
   }
 }

--- a/Modules/feature-common/Sources/Config/Issuance/IssuanceFlowUiConfig.swift
+++ b/Modules/feature-common/Sources/Config/Issuance/IssuanceFlowUiConfig.swift
@@ -51,6 +51,6 @@ public struct IssuanceFlowUiConfig: UIConfigType, Equatable {
 public extension IssuanceFlowUiConfig {
   enum Flow: Equatable, Sendable {
     case noDocument
-    case extraDocument(DocumentTypeIdentifier?)
+    case extraDocument(filterType: DocumentTypeIdentifier?)
   }
 }

--- a/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
@@ -5622,6 +5622,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -5918,6 +5928,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -6369,6 +6387,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -6524,6 +6554,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/feature-dashboard/Sources/DI/FeatureDashboardAssembly.swift
+++ b/Modules/feature-dashboard/Sources/DI/FeatureDashboardAssembly.swift
@@ -35,7 +35,6 @@ public final class FeatureDashboardAssembly: Assembly {
 
     container.register(SettingsInteractor.self) { r in
       SettingsInteractorImpl(
-        prefsController: r.force(PrefsController.self),
         walletController: r.force(WalletKitController.self),
         configLogic: r.force(ConfigLogic.self)
       )
@@ -51,7 +50,6 @@ public final class FeatureDashboardAssembly: Assembly {
     container.register(DocumentTabInteractor.self) { r in
       DocumentTabInteractorImpl(
         walletKitController: r.force(WalletKitController.self),
-        prefsController: r.force(PrefsController.self),
         filterValidator: r.force(FilterValidator.self)
       )
     }

--- a/Modules/feature-dashboard/Sources/Interactor/Dashboard/DocumentTabInteractor.swift
+++ b/Modules/feature-dashboard/Sources/Interactor/Dashboard/DocumentTabInteractor.swift
@@ -73,7 +73,6 @@ public protocol DocumentTabInteractor: Sendable {
 final class DocumentTabInteractorImpl: DocumentTabInteractor {
 
   private let walletKitController: WalletKitController
-  private let prefsController: PrefsController
   private let filterValidator: FilterValidator
 
   @MainActor
@@ -81,11 +80,9 @@ final class DocumentTabInteractorImpl: DocumentTabInteractor {
 
   init(
     walletKitController: WalletKitController,
-    prefsController: PrefsController,
     filterValidator: FilterValidator
   ) {
     self.walletKitController = walletKitController
-    self.prefsController = prefsController
     self.filterValidator = filterValidator
   }
 
@@ -417,9 +414,7 @@ final class DocumentTabInteractorImpl: DocumentTabInteractor {
       let documentPayload = document.transformToDocumentTabUi(
         categories: self.walletKitController.getDocumentCategories(),
         isRevoked: isRevoked,
-        usageCount: isBatchCounterEnabled()
-        ? getCredentialsUsageCount(credentialsUsageCounts: document.credentialsUsageCounts)
-        : nil
+        usageCount: getCredentialsUsageCount(credentialsUsageCounts: document.credentialsUsageCounts)
       )
 
       let documentSearchTags: [String] = {
@@ -519,9 +514,5 @@ final class DocumentTabInteractorImpl: DocumentTabInteractor {
     }
 
     return filterItems
-  }
-
-  private func isBatchCounterEnabled() -> Bool {
-    prefsController.getBool(forKey: .batchCounter)
   }
 }

--- a/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
+++ b/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
@@ -44,11 +44,8 @@ final class DocumentDetailsInteractorImpl: DocumentDetailsInteractor {
     let isBookmarked = await walletController.isDocumentBookmarked(with: documentId)
     let isRevoked = await walletController.isDocumentRevoked(with: documentId)
 
-    if isBatchCounterEnabled() {
-      let info = getCredentialsUsageCount(credentialsUsageCounts: document?.credentialsUsageCounts)
-      return .success(documentDetails, info, isBookmarked, isRevoked)
-    }
-    return .success(documentDetails, nil, isBookmarked, isRevoked)
+    let info = getCredentialsUsageCount(credentialsUsageCounts: document?.credentialsUsageCounts)
+    return .success(documentDetails, info, isBookmarked, isRevoked)
   }
 
   func deleteDocument(with documentId: String, and type: DocumentTypeIdentifier) async -> DocumentDetailsDeletionPartialState {
@@ -121,10 +118,6 @@ final class DocumentDetailsInteractorImpl: DocumentDetailsInteractor {
         hideButtonText: .documentDetailsDocumentCredentialsExpandedButtonHideText
       )
     )
-  }
-
-  private func isBatchCounterEnabled() -> Bool {
-    prefsController.getBool(forKey: .batchCounter)
   }
 }
 

--- a/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
+++ b/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
@@ -115,6 +115,7 @@ final class DocumentDetailsInteractorImpl: DocumentDetailsInteractor {
       ),
       expandedInfo: ExpandedInfo(
         subtitle: .documentDetailsDocumentCredentialsExpandedTextSubtitle,
+        updateNowButtonText: .expandableDocumentCredentialsUpdateButton,
         hideButtonText: .documentDetailsDocumentCredentialsExpandedButtonHideText
       )
     )

--- a/Modules/feature-dashboard/Sources/Interactor/SettingsInteractor.swift
+++ b/Modules/feature-dashboard/Sources/Interactor/SettingsInteractor.swift
@@ -21,22 +21,17 @@ public protocol SettingsInteractor: Sendable {
   func getAppVersion() -> String
   func retrieveLogFileUrl() -> URL?
   func retrieveChangeLogUrl() -> URL?
-  func setBatchCounter(isEnabled: Bool)
-  func isBatchCounterEnabled() -> Bool
 }
 
 final class SettingsInteractorImpl: SettingsInteractor {
 
-  private let prefsController: PrefsController
   private let walletController: WalletKitController
   private let configLogic: ConfigLogic
 
   init(
-    prefsController: PrefsController,
     walletController: WalletKitController,
     configLogic: ConfigLogic
   ) {
-    self.prefsController = prefsController
     self.walletController = walletController
     self.configLogic = configLogic
   }
@@ -51,13 +46,5 @@ final class SettingsInteractorImpl: SettingsInteractor {
 
   func retrieveChangeLogUrl() -> URL? {
     return configLogic.changelogUrl
-  }
-
-  func isBatchCounterEnabled() -> Bool {
-    prefsController.getBool(forKey: .batchCounter)
-  }
-
-  func setBatchCounter(isEnabled: Bool) {
-    prefsController.setValue(isEnabled, forKey: .batchCounter)
   }
 }

--- a/Modules/feature-dashboard/Sources/UI/Dashboard/Model/DocumentTabUIModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Dashboard/Model/DocumentTabUIModel.swift
@@ -67,6 +67,7 @@ extension DocClaimsDecodable {
     with failedDocuments: [String] = [],
     categories: DocumentCategories,
     isRevoked: Bool,
+    documentIsLowOnCredentials: Bool = false,
     usageCount: (remaining: Int?, total: Int?)? = nil
   ) -> DocumentTabUIModel {
     let state: DocumentTabUIModel.Value.State = failedDocuments.contains(where: { $0 == self.id })
@@ -111,8 +112,8 @@ extension DocClaimsDecodable {
           image: Theme.shared.image.id
         ),
         trailingContent: .textWithIcon(
-          indicatorImage(state),
-          supportingColor(state),
+          indicatorImage(state, documentIsLowOnCredentials: documentIsLowOnCredentials),
+          indicatorImageColor(state, documentIsLowOnCredentials: documentIsLowOnCredentials),
           getUsageCount(usage: usageCount)
         )
       )
@@ -152,31 +153,58 @@ extension DocClaimsDecodable {
   ) -> Color {
     if hasExpired {
       return Theme.shared.color.error
-    } else {
-      switch state {
-      case .issued:
-        return Theme.shared.color.onSurfaceVariant
-      case .pending:
-        return Theme.shared.color.warning
-      case .failed:
-        return Theme.shared.color.error
-      case .revoked:
-        return Theme.shared.color.error
-      }
+    }
+
+    switch state {
+    case .issued:
+      return Theme.shared.color.onSurfaceVariant
+    case .pending:
+      return Theme.shared.color.warning
+    case .failed, .revoked:
+      return Theme.shared.color.error
+    }
+  }
+
+  func indicatorImageColor(
+    _ state: DocumentTabUIModel.Value.State,
+    documentIsLowOnCredentials: Bool
+  ) -> Color {
+    if hasExpired {
+      return Theme.shared.color.error
+    }
+
+    if documentIsLowOnCredentials {
+      return Theme.shared.color.warning
+    }
+
+    switch state {
+    case .issued:
+      return Theme.shared.color.onSurfaceVariant
+    case .pending:
+      return Theme.shared.color.warning
+    case .failed, .revoked:
+      return Theme.shared.color.error
     }
   }
 
   func indicatorImage(
-    _ state: DocumentTabUIModel.Value.State
+    _ state: DocumentTabUIModel.Value.State,
+    documentIsLowOnCredentials: Bool
   ) -> Image {
+    if hasExpired {
+      return Theme.shared.image.errorIndicator
+    }
+
+    if documentIsLowOnCredentials {
+      return Theme.shared.image.errorIndicator
+    }
+
     switch state {
     case .issued:
       return Theme.shared.image.chevronRight
     case .pending:
       return Theme.shared.image.clockIndicator
-    case .failed:
-      return Theme.shared.image.errorIndicator
-    case .revoked:
+    case .failed, .revoked:
       return Theme.shared.image.errorIndicator
     }
   }

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/DocumentCredentialsInfo.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/DocumentCredentialsInfo.swift
@@ -51,12 +51,12 @@ public struct CollapsedInfo: Sendable {
 
 public struct ExpandedInfo: Sendable {
   public let subtitle: LocalizableStringKey
-  public let updateNowButtonText: LocalizableStringKey
+  public let updateNowButtonText: LocalizableStringKey?
   public let hideButtonText: LocalizableStringKey
 
   public init(
     subtitle: LocalizableStringKey,
-    updateNowButtonText: LocalizableStringKey,
+    updateNowButtonText: LocalizableStringKey? = nil,
     hideButtonText: LocalizableStringKey
   ) {
     self.subtitle = subtitle

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/DocumentCredentialsInfo.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/DocumentCredentialsInfo.swift
@@ -22,19 +22,22 @@ public struct DocumentCredentialsInfoUi: Sendable {
   public let title: LocalizableStringKey
   public let collapsedInfo: CollapsedInfo?
   public let expandedInfo: ExpandedInfo?
+  public let isExpanded: Bool
 
   public init(
     availableCredentials: Int,
     totalCredentials: Int,
     title: LocalizableStringKey,
     collapsedInfo: CollapsedInfo? = nil,
-    expandedInfo: ExpandedInfo? = nil
+    expandedInfo: ExpandedInfo? = nil,
+    isExpanded: Bool = false
   ) {
     self.availableCredentials = availableCredentials
     self.totalCredentials = totalCredentials
     self.title = title
     self.collapsedInfo = collapsedInfo
     self.expandedInfo = expandedInfo
+    self.isExpanded = isExpanded
   }
 }
 
@@ -48,12 +51,12 @@ public struct CollapsedInfo: Sendable {
 
 public struct ExpandedInfo: Sendable {
   public let subtitle: LocalizableStringKey
-  public let updateNowButtonText: LocalizableStringKey?
+  public let updateNowButtonText: LocalizableStringKey
   public let hideButtonText: LocalizableStringKey
 
   public init(
     subtitle: LocalizableStringKey,
-    updateNowButtonText: LocalizableStringKey? = nil,
+    updateNowButtonText: LocalizableStringKey,
     hideButtonText: LocalizableStringKey
   ) {
     self.subtitle = subtitle

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
@@ -80,6 +80,7 @@ struct ExpandableDocumentCredentialsView: View {
               style: .primary,
               title: updateNowButtonText,
               gravity: .none,
+              cornerRadius: Theme.shared.shape.large,
               onAction: onPrimaryButtonClicked()
             )
           }

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
@@ -76,21 +76,12 @@ struct ExpandableDocumentCredentialsView: View {
           }
 
           if let updateNowButtonText = info.updateNowButtonText {
-            Button {
-              withAnimation {
-                onPrimaryButtonClicked()
-              }
-            } label: {
-              Text(updateNowButtonText)
-                .padding()
-                .foregroundColor(Theme.shared.color.onPrimary)
-                .background(Theme.shared.color.primary)
-                .cornerRadius(Theme.shared.shape.small)
-                .overlay(
-                  RoundedRectangle(cornerRadius: Theme.shared.shape.small)
-                    .stroke(Theme.shared.color.primary, lineWidth: 1)
-                )
-            }
+            WrapButtonView(
+              style: .primary,
+              title: updateNowButtonText,
+              gravity: .none,
+              onAction: onPrimaryButtonClicked()
+            )
           }
         }
       }

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
@@ -59,7 +59,7 @@ struct ExpandableDocumentCredentialsView: View {
             .multilineTextAlignment(.leading)
         }
 
-        HStack {
+        HStack(spacing: SPACING_MEDIUM) {
           Spacer()
           Button {
             withAnimation {
@@ -69,6 +69,22 @@ struct ExpandableDocumentCredentialsView: View {
             Text(info.hideButtonText)
               .font(Theme.shared.font.bodyLarge.font)
               .foregroundColor(Theme.shared.color.primary)
+          }
+
+          Button {
+            withAnimation {
+              isExpanded.toggle()
+            }
+          } label: {
+            Text(LocalizableStringKey.expandableDocumentCredentialsUpdateButton)
+              .padding()
+              .foregroundColor(Theme.shared.color.onPrimary)
+              .background(Theme.shared.color.primary)
+              .cornerRadius(22)
+              .overlay(
+                RoundedRectangle(cornerRadius: 22)
+                  .stroke(Theme.shared.color.primary, lineWidth: 1)
+              )
           }
         }
       }
@@ -116,7 +132,7 @@ struct ExpandableDocumentCredentialsView: View {
         moreInfoText: .custom("More Info")
       ),
       expandedInfo: ExpandedInfo(
-        subtitle: .custom("For security reasons, this document can be shared a limited number of times before it needs to be re-issued by the issuing authority."),
+        subtitle: .custom("For security reasons, this document can be shared a limited number of times before it needs to be re-issued by the issuing authority."), updateNowButtonText: .custom("Update now"),
         hideButtonText: .custom("Hide")
       )
     )

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/Component/ExpandableDocumentCredentialsView.swift
@@ -22,13 +22,17 @@ struct ExpandableDocumentCredentialsView: View {
 
   private let backgroundColor: Color
   private let documentCredentialsInfo: DocumentCredentialsInfoUi
+  private let onPrimaryButtonClicked: () -> Void
 
   init(
     backgroundColor: Color = Theme.shared.color.surfaceContainer,
-    documentCredentialsInfo: DocumentCredentialsInfoUi
+    documentCredentialsInfo: DocumentCredentialsInfoUi,
+    onPrimaryButtonClicked: @escaping () -> Void
   ) {
+    self.isExpanded = documentCredentialsInfo.isExpanded
     self.backgroundColor = backgroundColor
     self.documentCredentialsInfo = documentCredentialsInfo
+    self.onPrimaryButtonClicked = onPrimaryButtonClicked
   }
 
   var body: some View {
@@ -71,20 +75,22 @@ struct ExpandableDocumentCredentialsView: View {
               .foregroundColor(Theme.shared.color.primary)
           }
 
-          Button {
-            withAnimation {
-              isExpanded.toggle()
+          if let updateNowButtonText = info.updateNowButtonText {
+            Button {
+              withAnimation {
+                onPrimaryButtonClicked()
+              }
+            } label: {
+              Text(updateNowButtonText)
+                .padding()
+                .foregroundColor(Theme.shared.color.onPrimary)
+                .background(Theme.shared.color.primary)
+                .cornerRadius(Theme.shared.shape.small)
+                .overlay(
+                  RoundedRectangle(cornerRadius: Theme.shared.shape.small)
+                    .stroke(Theme.shared.color.primary, lineWidth: 1)
+                )
             }
-          } label: {
-            Text(LocalizableStringKey.expandableDocumentCredentialsUpdateButton)
-              .padding()
-              .foregroundColor(Theme.shared.color.onPrimary)
-              .background(Theme.shared.color.primary)
-              .cornerRadius(22)
-              .overlay(
-                RoundedRectangle(cornerRadius: 22)
-                  .stroke(Theme.shared.color.primary, lineWidth: 1)
-              )
           }
         }
       }
@@ -135,6 +141,7 @@ struct ExpandableDocumentCredentialsView: View {
         subtitle: .custom("For security reasons, this document can be shared a limited number of times before it needs to be re-issued by the issuing authority."), updateNowButtonText: .custom("Update now"),
         hideButtonText: .custom("Hide")
       )
-    )
+    ),
+    onPrimaryButtonClicked: {}
   )
 }

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsView.swift
@@ -164,6 +164,7 @@ private func content(
       ),
       expandedInfo: ExpandedInfo(
         subtitle: .custom("For security reasons, this document can be shared a limited number of times before it needs to be re-issued by the issuing authority."),
+        updateNowButtonText: .custom("Update now"),
         hideButtonText: .custom("Hide")
       )
     )

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsView.swift
@@ -51,6 +51,8 @@ struct DocumentDetailsView<Router: RouterHost>: View {
         viewModel.onContinue()
       } onShowDeleteModal: {
         viewModel.onShowDeleteModal()
+      } issueNewDocument: {
+        viewModel.issueNewDocument()
       }
     }
     .confirmationDialog(
@@ -86,7 +88,8 @@ private func content(
   isVisible: Bool,
   showAlert: @escaping () -> Void,
   onContinue: @escaping () -> Void,
-  onShowDeleteModal: @escaping () -> Void
+  onShowDeleteModal: @escaping () -> Void,
+  issueNewDocument: @escaping () -> Void
 ) -> some View {
   ScrollView {
     VStack(alignment: .leading, spacing: SPACING_MEDIUM) {
@@ -105,7 +108,8 @@ private func content(
 
       if let credentialsInfo = viewState.documentCredentialsInfo {
         ExpandableDocumentCredentialsView(
-          documentCredentialsInfo: credentialsInfo
+          documentCredentialsInfo: credentialsInfo,
+          onPrimaryButtonClicked: issueNewDocument
         )
       }
 
@@ -179,7 +183,8 @@ private func content(
       isVisible: true,
       showAlert: {},
       onContinue: {},
-      onShowDeleteModal: {}
+      onShowDeleteModal: {},
+      issueNewDocument: {}
     )
   }
 }

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsViewModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsViewModel.swift
@@ -112,6 +112,18 @@ final class DocumentDetailsViewModel<Router: RouterHost>: ViewModel<Router, Docu
     isDeletionModalShowing = !isDeletionModalShowing
   }
 
+  func issueNewDocument() {
+    router.push(
+      with: .featureIssuanceModule(
+        .issuanceAddDocument(
+          config: IssuanceFlowUiConfig(
+            flow: .extraDocument(viewState.document.type)
+          )
+        )
+      )
+    )
+  }
+
   func saveBookmark(_ identifier: String) {
     Task {
       do {

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsViewModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsViewModel.swift
@@ -117,7 +117,7 @@ final class DocumentDetailsViewModel<Router: RouterHost>: ViewModel<Router, Docu
       with: .featureIssuanceModule(
         .issuanceAddDocument(
           config: IssuanceFlowUiConfig(
-            flow: .extraDocument(viewState.document.type)
+            flow: .extraDocument(filterType: viewState.document.type)
           )
         )
       )

--- a/Modules/feature-dashboard/Sources/UI/Issuance/IssuanceOptionViewModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Issuance/IssuanceOptionViewModel.swift
@@ -64,7 +64,7 @@ class IssuanceOptionViewModel<Router: RouterHost>: ViewModel<Router, IssuanceOpt
     router.push(
       with: .featureIssuanceModule(
         .issuanceAddDocument(
-          config: IssuanceFlowUiConfig(flow: .extraDocument)
+          config: IssuanceFlowUiConfig(flow: .extraDocument(nil))
         )
       )
     )

--- a/Modules/feature-dashboard/Sources/UI/Issuance/IssuanceOptionViewModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Issuance/IssuanceOptionViewModel.swift
@@ -64,7 +64,7 @@ class IssuanceOptionViewModel<Router: RouterHost>: ViewModel<Router, IssuanceOpt
     router.push(
       with: .featureIssuanceModule(
         .issuanceAddDocument(
-          config: IssuanceFlowUiConfig(flow: .extraDocument(nil))
+          config: IssuanceFlowUiConfig(flow: .extraDocument(filterType: nil))
         )
       )
     )

--- a/Modules/feature-dashboard/Sources/UI/Settings/SettingsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Settings/SettingsView.swift
@@ -31,8 +31,7 @@ struct SettingsView<Router: RouterHost>: View {
       toolbarContent: viewModel.toolbarContent()
     ) {
       content(
-        viewState: viewModel.viewState,
-        isBatchCounterEnabled: $viewModel.isBatchCounterEnabled
+        viewState: viewModel.viewState
       )
     }
   }
@@ -41,8 +40,7 @@ struct SettingsView<Router: RouterHost>: View {
 @MainActor
 @ViewBuilder
 private func content(
-  viewState: SettingsViewState,
-  isBatchCounterEnabled: Binding<Bool>
+  viewState: SettingsViewState
 ) -> some View {
   VStack(spacing: SPACING_MEDIUM_SMALL) {
     ForEach(viewState.items) { item in
@@ -57,14 +55,6 @@ private func content(
             )
           }
         }
-      } else if item.isToggle {
-        TappableCellView(
-          title: item.title,
-          showDivider: item.showDivider,
-          isToggle: true,
-          isOn: isBatchCounterEnabled,
-          action: item.action()
-        )
       } else {
         TappableCellView(
           title: item.title,
@@ -101,8 +91,7 @@ private func content(
     background: Theme.shared.color.surface
   ) {
     content(
-      viewState: viewSate,
-      isBatchCounterEnabled: .constant(true)
+      viewState: viewSate
     )
   }
 }

--- a/Modules/feature-dashboard/Sources/UI/Settings/SettingsViewModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Settings/SettingsViewModel.swift
@@ -26,7 +26,6 @@ struct SettingsViewState: ViewState {
 }
 
 final class SettingsViewModel<Router: RouterHost>: ViewModel<Router, SettingsViewState> {
-  @Published var isBatchCounterEnabled: Bool = false
 
   private let interactor: SettingsInteractor
   private let walletKitController: WalletKitController
@@ -49,7 +48,6 @@ final class SettingsViewModel<Router: RouterHost>: ViewModel<Router, SettingsVie
     )
 
     buildMenuItems()
-    subscribeBatchToggle()
   }
 
   func toolbarContent() -> ToolBarContent {
@@ -65,15 +63,7 @@ final class SettingsViewModel<Router: RouterHost>: ViewModel<Router, SettingsVie
 
   private func buildMenuItems() {
 
-    isBatchCounterEnabled = interactor.isBatchCounterEnabled()
-
     var items: [SettingMenuItemUIModel] = [
-      .init(
-        title: .batchIssuanceCunter,
-        showDivider: true,
-        isToggle: true,
-        action: self.updateBatchCounter(self.isBatchCounterEnabled)
-      ),
       .init(
         title: .retrieveLogs,
         isShareLink: true,
@@ -92,19 +82,5 @@ final class SettingsViewModel<Router: RouterHost>: ViewModel<Router, SettingsVie
     }
 
     setState { $0.copy(items: items) }
-  }
-
-  private func subscribeBatchToggle() {
-    $isBatchCounterEnabled
-      .dropFirst()
-      .removeDuplicates()
-      .sink { [weak self] isEnabled in
-        guard let self = self else { return }
-        self.updateBatchCounter(isEnabled)
-      }.store(in: &cancellables)
-  }
-
-  private func updateBatchCounter(_ isEnabled: Bool) {
-    interactor.setBatchCounter(isEnabled: isEnabled)
   }
 }

--- a/Modules/feature-dashboard/Tests/Interactor/TestDocumentDetailsInteractor.swift
+++ b/Modules/feature-dashboard/Tests/Interactor/TestDocumentDetailsInteractor.swift
@@ -49,6 +49,7 @@ final class TestDocumentDetailsInteractor: EudiTest {
     stubFetchDocument(for: documentId, document: expectedDocument)
     stubIsBookmarked(for: documentId, isBookmarked: false)
     stubIsRevoked(for: documentId, isRevoked: false)
+    stubIsDocumentLowOnCredentials()
 
     // When
     let result = await interactor.fetchStoredDocument(documentId: documentId)
@@ -74,6 +75,7 @@ final class TestDocumentDetailsInteractor: EudiTest {
     stubFetchDocument(for: documentId, document: expectedDocument)
     stubIsBookmarked(for: documentId, isBookmarked: false)
     stubIsRevoked(for: documentId, isRevoked: false)
+    stubIsDocumentLowOnCredentials()
 
     // When
     let result = await interactor.fetchStoredDocument(documentId: documentId)
@@ -97,6 +99,7 @@ final class TestDocumentDetailsInteractor: EudiTest {
     stubFetchDocument(for: documentId, document: expectedDocument)
     stubIsBookmarked(for: documentId, isBookmarked: false)
     stubIsRevoked(for: documentId, isRevoked: false)
+    stubIsDocumentLowOnCredentials()
 
     // When
     let result = await interactor.fetchStoredDocument(documentId: documentId)
@@ -327,7 +330,14 @@ extension TestDocumentDetailsInteractor {
         .thenReturn(document)
     }
   }
-  
+
+  func stubIsDocumentLowOnCredentials(hasLowOnCredentials: Bool = true) {
+    stub(walletKitController) { stub in
+      when(stub.isDocumentLowOnCredentials(document: any()))
+        .thenReturn(hasLowOnCredentials)
+    }
+  }
+
   func stubFetchDocumentFailure(for id: String) {
     stub(walletKitController) { stub in
       when(stub.fetchDocument(with: equal(to: id))).thenReturn(nil)

--- a/Modules/feature-dashboard/Tests/Interactor/TestDocumentDetailsInteractor.swift
+++ b/Modules/feature-dashboard/Tests/Interactor/TestDocumentDetailsInteractor.swift
@@ -49,7 +49,6 @@ final class TestDocumentDetailsInteractor: EudiTest {
     stubFetchDocument(for: documentId, document: expectedDocument)
     stubIsBookmarked(for: documentId, isBookmarked: false)
     stubIsRevoked(for: documentId, isRevoked: false)
-    stubIsBatchCounterEnabled()
 
     // When
     let result = await interactor.fetchStoredDocument(documentId: documentId)
@@ -75,7 +74,6 @@ final class TestDocumentDetailsInteractor: EudiTest {
     stubFetchDocument(for: documentId, document: expectedDocument)
     stubIsBookmarked(for: documentId, isBookmarked: false)
     stubIsRevoked(for: documentId, isRevoked: false)
-    stubIsBatchCounterEnabled(false)
 
     // When
     let result = await interactor.fetchStoredDocument(documentId: documentId)
@@ -99,7 +97,6 @@ final class TestDocumentDetailsInteractor: EudiTest {
     stubFetchDocument(for: documentId, document: expectedDocument)
     stubIsBookmarked(for: documentId, isBookmarked: false)
     stubIsRevoked(for: documentId, isRevoked: false)
-    stubIsBatchCounterEnabled()
 
     // When
     let result = await interactor.fetchStoredDocument(documentId: documentId)
@@ -426,12 +423,6 @@ extension TestDocumentDetailsInteractor {
     stub(walletKitController) { stub in
       when(stub.removeBookmarkedDocument(with: equal(to: id)))
         .thenThrow(WalletCoreError.unableFetchDocument)
-    }
-  }
-
-  func stubIsBatchCounterEnabled(_ enabled: Bool = true) {
-    stub(prefsController) { stub in
-      when(stub.getBool(forKey: Prefs.Key.batchCounter)).thenReturn(enabled)
     }
   }
 }

--- a/Modules/feature-dashboard/Tests/Interactor/TestDocumentTabInteractor.swift
+++ b/Modules/feature-dashboard/Tests/Interactor/TestDocumentTabInteractor.swift
@@ -134,7 +134,8 @@ final class TestDocumentTabInteractor: EudiTest {
     stubFetchDocumentCategories(with: documentsCategories)
     stubFetchDocumentsWithExclusion(with: [expectedMdl])
     stubFetchMainPidDocument(with: expectedPid)
-
+    stubIsDocumentLowOnCredentials()
+    
     // When
     let state = await interactor.fetchDocuments(failedDocuments: [])
     
@@ -482,6 +483,7 @@ final class TestDocumentTabInteractor: EudiTest {
     stubFetchDocumentCategories(with: documentsCategories)
     stubFetchDocumentsWithExclusion(with: [expectedMdl])
     stubFetchMainPidDocument(with: expectedPid)
+    stubIsDocumentLowOnCredentials()
 
     // When
     let state = await interactor.fetchDocuments(failedDocuments: [])
@@ -584,7 +586,14 @@ private extension TestDocumentTabInteractor {
       when(mock.fetchAllDocuments()).thenReturn([])
     }
   }
-  
+
+  func stubIsDocumentLowOnCredentials(hasLowOnCredentials: Bool = true) {
+    stub(walletKitController) { stub in
+      when(stub.isDocumentLowOnCredentials(document: any()))
+        .thenReturn(hasLowOnCredentials)
+    }
+  }
+
   func stubInitializeValidator() {
     stub(filterValidator) { mock in
       when(mock.initializeValidator(

--- a/Modules/feature-dashboard/Tests/Interactor/TestDocumentTabInteractor.swift
+++ b/Modules/feature-dashboard/Tests/Interactor/TestDocumentTabInteractor.swift
@@ -25,18 +25,15 @@ final class TestDocumentTabInteractor: EudiTest {
   
   var interactor: DocumentTabInteractor!
   var walletKitController: MockWalletKitController!
-  var prefsController: MockPrefsController!
   var filterValidator: MockFilterValidator!
   var configLogic: MockConfigLogic!
   
   override func setUp() {
     self.walletKitController = MockWalletKitController()
-    self.prefsController = MockPrefsController()
     self.configLogic = MockConfigLogic()
     self.filterValidator = MockFilterValidator()
     self.interactor = DocumentTabInteractorImpl(
       walletKitController: walletKitController,
-      prefsController: prefsController,
       filterValidator: filterValidator
     )
   }
@@ -44,7 +41,6 @@ final class TestDocumentTabInteractor: EudiTest {
   override func tearDown() {
     self.interactor = nil
     self.walletKitController = nil
-    self.prefsController = nil
     self.configLogic = nil
   }
   
@@ -90,7 +86,6 @@ final class TestDocumentTabInteractor: EudiTest {
     stubFetchIssuedDocuments(with: [])
     stubFetchDocumentsWithExclusion(with: [])
     stubFetchMainPidDocument(with: nil)
-    stubIsBatchCounterEnabled()
 
     // When
     let state = await interactor.fetchDocuments(failedDocuments: [])
@@ -139,7 +134,6 @@ final class TestDocumentTabInteractor: EudiTest {
     stubFetchDocumentCategories(with: documentsCategories)
     stubFetchDocumentsWithExclusion(with: [expectedMdl])
     stubFetchMainPidDocument(with: expectedPid)
-    stubIsBatchCounterEnabled()
 
     // When
     let state = await interactor.fetchDocuments(failedDocuments: [])
@@ -488,7 +482,6 @@ final class TestDocumentTabInteractor: EudiTest {
     stubFetchDocumentCategories(with: documentsCategories)
     stubFetchDocumentsWithExclusion(with: [expectedMdl])
     stubFetchMainPidDocument(with: expectedPid)
-    stubIsBatchCounterEnabled()
 
     // When
     let state = await interactor.fetchDocuments(failedDocuments: [])
@@ -647,12 +640,6 @@ private extension TestDocumentTabInteractor {
         query: equal(to: "search"))
       )
       .thenDoNothing()
-    }
-  }
-
-  func stubIsBatchCounterEnabled(_ enabled: Bool = true) {
-    stub(prefsController) { stub in
-      when(stub.getBool(forKey: Prefs.Key.batchCounter)).thenReturn(enabled)
     }
   }
 }

--- a/Modules/feature-dashboard/Tests/Interactor/TestSettingsInteractor.swift
+++ b/Modules/feature-dashboard/Tests/Interactor/TestSettingsInteractor.swift
@@ -28,10 +28,8 @@ final class TestSettingsInteractor: EudiTest {
 
   override func setUp() {
     self.walletKitController = MockWalletKitController()
-    self.prefsController = MockPrefsController()
     self.configLogic = MockConfigLogic()
     self.interactor = SettingsInteractorImpl(
-      prefsController: prefsController,
       walletController: walletKitController,
       configLogic: configLogic
     )
@@ -41,7 +39,6 @@ final class TestSettingsInteractor: EudiTest {
     self.interactor = nil
     self.walletKitController = nil
     self.configLogic = nil
-    self.prefsController = nil
   }
 
   func testGetAppVersion_WhenConfigLogicReturnsAppVersion_ThenReturnsExpectedVersion() {
@@ -75,45 +72,6 @@ final class TestSettingsInteractor: EudiTest {
 
     // Then
     XCTAssertEqual(result, expectedUrl)
-  }
-
-  func testIsBatchCounterEnabled_WhenPrefsControllerReturnsTrue_ThenReturnsTrue() {
-    // Given
-    stub(prefsController) { mock in
-      when(mock.getBool(forKey: Prefs.Key.batchCounter)).thenReturn(true)
-    }
-
-    // When
-    let result = interactor.isBatchCounterEnabled()
-
-    // Then
-    XCTAssertTrue(result)
-  }
-
-  func testIsBatchCounterEnabled_WhenPrefsControllerReturnsFalse_ThenReturnsFalse() {
-    // Given
-    stub(prefsController) { mock in
-      when(mock.getBool(forKey: Prefs.Key.batchCounter)).thenReturn(false)
-    }
-
-    // When
-    let result = interactor.isBatchCounterEnabled()
-
-    // Then
-    XCTAssertFalse(result)
-  }
-
-  func testBatchCounter_WhenSetToTrue_CallsPrefsControllerWithTrue() {
-    // Given
-    stub(prefsController) { mock in
-      when(mock.setValue(any(), forKey: Prefs.Key.batchCounter)).thenDoNothing()
-    }
-
-    // When
-    interactor.setBatchCounter(isEnabled: true)
-    
-    // Then
-    verify(prefsController).setValue(any(), forKey: Prefs.Key.batchCounter)
   }
 }
 

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -2704,26 +2704,6 @@ public class MockSettingsInteractor: SettingsInteractor, Cuckoo.ProtocolMock, @u
             defaultCall: __defaultImplStub!.retrieveChangeLogUrl()
         )
     }
-    
-    public func setBatchCounter(isEnabled p0: Bool) {
-        return cuckoo_manager.call(
-            "setBatchCounter(isEnabled p0: Bool)",
-            parameters: (p0),
-            escapingParameters: (p0),
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: __defaultImplStub!.setBatchCounter(isEnabled: p0)
-        )
-    }
-    
-    public func isBatchCounterEnabled() -> Bool {
-        return cuckoo_manager.call(
-            "isBatchCounterEnabled() -> Bool",
-            parameters: (),
-            escapingParameters: (),
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: __defaultImplStub!.isBatchCounterEnabled()
-        )
-    }
 
     public struct __StubbingProxy_SettingsInteractor: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -2752,22 +2732,6 @@ public class MockSettingsInteractor: SettingsInteractor, Cuckoo.ProtocolMock, @u
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockSettingsInteractor.self,
                 method: "retrieveChangeLogUrl() -> URL?",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func setBatchCounter<M1: Cuckoo.Matchable>(isEnabled p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
-            let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockSettingsInteractor.self,
-                method: "setBatchCounter(isEnabled p0: Bool)",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func isBatchCounterEnabled() -> Cuckoo.ProtocolStubFunction<(), Bool> {
-            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockSettingsInteractor.self,
-                method: "isBatchCounterEnabled() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -2819,30 +2783,6 @@ public class MockSettingsInteractor: SettingsInteractor, Cuckoo.ProtocolMock, @u
                 sourceLocation: sourceLocation
             )
         }
-        
-        
-        @discardableResult
-        func setBatchCounter<M1: Cuckoo.Matchable>(isEnabled p0: M1) -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool {
-            let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "setBatchCounter(isEnabled p0: Bool)",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func isBatchCounterEnabled() -> Cuckoo.__DoNotUse<(), Bool> {
-            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return cuckoo_manager.verify(
-                "isBatchCounterEnabled() -> Bool",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
     }
 }
 
@@ -2860,14 +2800,6 @@ public class SettingsInteractorStub:SettingsInteractor, @unchecked Sendable {
     
     public func retrieveChangeLogUrl() -> URL? {
         return DefaultValueRegistry.defaultValue(for: (URL?).self)
-    }
-    
-    public func setBatchCounter(isEnabled p0: Bool) {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func isBatchCounterEnabled() -> Bool {
-        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -8043,6 +8043,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -8339,6 +8349,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -8790,6 +8808,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -8945,6 +8975,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/feature-issuance/Sources/Interactor/AddDocumentInteractor.swift
+++ b/Modules/feature-issuance/Sources/Interactor/AddDocumentInteractor.swift
@@ -38,19 +38,25 @@ final class AddDocumentInteractorImpl: AddDocumentInteractor {
   public func fetchScopedDocuments(with flow: IssuanceFlowUiConfig.Flow) async -> ScopedDocumentsPartialState {
     do {
       let documents: [AddDocumentUIModel] = try await walletController.getScopedDocuments().compactMap { doc in
-        if flow == .extraDocument || doc.isPid {
-          return .init(
-            listItem: .init(
-              mainText: .custom(doc.name),
-              trailingContent: .icon(Theme.shared.image.plus)
-            ),
-            isEnabled: true,
-            configId: doc.configId,
-            docTypeIdentifier: doc.docTypeIdentifier
-          )
-        } else {
-          return nil
+        switch flow {
+        case .noDocument:
+          guard doc.isPid else { return nil }
+
+        case .extraDocument(let identifier):
+          if let identifier, doc.docTypeIdentifier != identifier {
+            return nil
+          }
         }
+
+        return .init(
+          listItem: .init(
+            mainText: .custom(doc.name),
+            trailingContent: .icon(Theme.shared.image.plus)
+          ),
+          isEnabled: true,
+          configId: doc.configId,
+          docTypeIdentifier: doc.docTypeIdentifier
+        )
       }.sorted(by: compare)
       return .success(documents)
     } catch {

--- a/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentView.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentView.swift
@@ -75,13 +75,17 @@ private func content(
         .foregroundStyle(Theme.shared.color.onSurface)
 
       VStack(spacing: SPACING_MEDIUM_SMALL) {
-        ForEach(viewState.addDocumentCellModels) { cell in
-          WrapCardView {
-            WrapListItemView(
-              listItem: cell.listItem,
-              isLoading: cell.isLoading,
-              action: { action(cell.configId, cell.docTypeIdentifier) }
-            )
+        if viewState.addDocumentCellModels.isEmpty {
+          noDocumentsFound()
+        } else {
+          ForEach(viewState.addDocumentCellModels) { cell in
+            WrapCardView {
+              WrapListItemView(
+                listItem: cell.listItem,
+                isLoading: cell.isLoading,
+                action: { action(cell.configId, cell.docTypeIdentifier) }
+              )
+            }
           }
         }
       }
@@ -89,6 +93,17 @@ private func content(
     .padding(.horizontal, Theme.shared.dimension.padding)
     .padding(.bottom)
   }
+}
+
+@MainActor
+@ViewBuilder
+private func noDocumentsFound() -> some View {
+  VStack(spacing: .zero) {
+    ContentEmptyView(
+      title: .issuanceAddDocumentNoOptions
+    )
+  }
+  .padding(.horizontal, Theme.shared.dimension.padding)
 }
 
 @MainActor

--- a/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentView.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentView.swift
@@ -39,9 +39,12 @@ struct AddDocumentView<Router: RouterHost>: View {
       isLoading: viewModel.viewState.isLoading,
       toolbarContent: viewModel.toolbarContent()
     ) {
-
-      content(viewState: viewModel.viewState) { configId, identifier in
-        viewModel.onClick(configId: configId, docTypeIdentifier: identifier)
+      if viewModel.viewState.addDocumentCellModels.isEmpty {
+        noDocumentsFound()
+      } else {
+        content(viewState: viewModel.viewState) { configId, identifier in
+          viewModel.onClick(configId: configId, docTypeIdentifier: identifier)
+        }
       }
 
       if viewModel.viewState.showFooterScanner {
@@ -75,17 +78,13 @@ private func content(
         .foregroundStyle(Theme.shared.color.onSurface)
 
       VStack(spacing: SPACING_MEDIUM_SMALL) {
-        if viewState.addDocumentCellModels.isEmpty {
-          noDocumentsFound()
-        } else {
-          ForEach(viewState.addDocumentCellModels) { cell in
-            WrapCardView {
-              WrapListItemView(
-                listItem: cell.listItem,
-                isLoading: cell.isLoading,
-                action: { action(cell.configId, cell.docTypeIdentifier) }
-              )
-            }
+        ForEach(viewState.addDocumentCellModels) { cell in
+          WrapCardView {
+            WrapListItemView(
+              listItem: cell.listItem,
+              isLoading: cell.isLoading,
+              action: { action(cell.configId, cell.docTypeIdentifier) }
+            )
           }
         }
       }
@@ -93,15 +92,22 @@ private func content(
     .padding(.horizontal, Theme.shared.dimension.padding)
     .padding(.bottom)
   }
+  .disabled(viewState.addDocumentCellModels.isEmpty)
 }
 
 @MainActor
 @ViewBuilder
 private func noDocumentsFound() -> some View {
   VStack(spacing: .zero) {
+    Text(.chooseFromListTitle)
+      .typography(Theme.shared.font.bodyLarge)
+      .foregroundStyle(Theme.shared.color.onSurface)
+
+    Spacer()
     ContentEmptyView(
       title: .issuanceAddDocumentNoOptions
     )
+    Spacer()
   }
   .padding(.horizontal, Theme.shared.dimension.padding)
 }

--- a/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentViewModel.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentViewModel.swift
@@ -81,7 +81,8 @@ final class AddDocumentViewModel<Router: RouterHost>: ViewModel<Router, AddDocum
     case .success(let documents):
       setState {
         $0.copy(
-          addDocumentCellModels: documents
+          addDocumentCellModels: documents,
+          showFooterScanner: viewState.addDocumentCellModels.isEmpty
         )
         .copy(error: nil)
       }
@@ -111,12 +112,21 @@ final class AddDocumentViewModel<Router: RouterHost>: ViewModel<Router, AddDocum
   }
 
   func onScanClick() {
+    var successNavigation: UIConfig.TwoWayNavigationType {
+      switch viewState.config.flow {
+      case .noDocument:
+        .push(.featureDashboardModule(.dashboard))
+      case .extraDocument:
+        .popTo(.featureDashboardModule(.dashboard))
+      }
+    }
+
     router.push(
       with: .featureCommonModule(
         .qrScanner(
           config: ScannerUiConfig(
             flow: .issuing(
-              successNavigation: .push(.featureDashboardModule(.dashboard)),
+              successNavigation: successNavigation,
               cancelNavigation: .popTo(
                 .featureIssuanceModule(
                   .issuanceAddDocument(config: viewState.config)

--- a/Modules/feature-issuance/Tests/Interactor/TestAddDocumentInteractor.swift
+++ b/Modules/feature-issuance/Tests/Interactor/TestAddDocumentInteractor.swift
@@ -46,7 +46,7 @@ final class TestAddDocumentInteractor: EudiTest {
     ])
     
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument)
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
 
     // Then
     switch result {
@@ -66,7 +66,7 @@ final class TestAddDocumentInteractor: EudiTest {
     ])
 
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument)
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
 
     // Then
     switch result {
@@ -100,8 +100,8 @@ final class TestAddDocumentInteractor: EudiTest {
     stubGetScopedDocumentsFailure()
     
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument)
-    
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
+
     // Then
     switch result {
     case .failure(let error):
@@ -456,7 +456,7 @@ final class TestAddDocumentInteractor: EudiTest {
     ])
 
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument)
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
 
     // Then
     switch result {

--- a/Modules/feature-issuance/Tests/Interactor/TestAddDocumentInteractor.swift
+++ b/Modules/feature-issuance/Tests/Interactor/TestAddDocumentInteractor.swift
@@ -46,7 +46,7 @@ final class TestAddDocumentInteractor: EudiTest {
     ])
     
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(filterType: nil))
 
     // Then
     switch result {
@@ -66,7 +66,7 @@ final class TestAddDocumentInteractor: EudiTest {
     ])
 
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(filterType: nil))
 
     // Then
     switch result {
@@ -100,7 +100,7 @@ final class TestAddDocumentInteractor: EudiTest {
     stubGetScopedDocumentsFailure()
     
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(filterType: nil))
 
     // Then
     switch result {
@@ -456,7 +456,7 @@ final class TestAddDocumentInteractor: EudiTest {
     ])
 
     // When
-    let result = await interactor.fetchScopedDocuments(with: .extraDocument(nil))
+    let result = await interactor.fetchScopedDocuments(with: .extraDocument(filterType: nil))
 
     // Then
     switch result {

--- a/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
@@ -6272,6 +6272,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -6568,6 +6578,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -7019,6 +7037,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -7174,6 +7204,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -6103,6 +6103,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -6399,6 +6409,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -6850,6 +6868,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -7005,6 +7035,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
@@ -6100,6 +6100,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -6396,6 +6406,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -6847,6 +6865,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -7002,6 +7032,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
@@ -5818,6 +5818,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -6114,6 +6124,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -6565,6 +6583,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -6720,6 +6750,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/feature-test/Sources/Utils/Constants.swift
+++ b/Modules/feature-test/Sources/Utils/Constants.swift
@@ -57,6 +57,7 @@ extension Constants {
       validUntil: nil,
       statusIdentifier: nil,
       credentialsUsageCounts: credentialsUsageCounts,
+      credentialPolicy: .oneTimeUse,
       secureAreaName: nil,
       modifiedAt: nil,
       docClaims: [
@@ -95,6 +96,7 @@ extension Constants {
       validUntil: nil,
       statusIdentifier: nil,
       credentialsUsageCounts: credentialsUsageCounts,
+      credentialPolicy: .oneTimeUse,
       secureAreaName: nil,
       modifiedAt: nil,
       docClaims: [

--- a/Modules/logic-api/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-api/Tests/Mock/GeneratedMocks.swift
@@ -4060,6 +4060,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -4356,6 +4366,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -4807,6 +4825,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -4962,6 +4992,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
@@ -4016,6 +4016,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -4312,6 +4322,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -4763,6 +4781,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -4918,6 +4948,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/logic-business/Sources/Controller/PrefsController.swift
+++ b/Modules/logic-business/Sources/Controller/PrefsController.swift
@@ -74,6 +74,5 @@ public extension Prefs {
     case cachedDeepLink
     case runAtLeastOnce
     case language
-    case batchCounter
   }
 }

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.13.4"
+      exact: "0.13.5"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -204,11 +204,11 @@ struct WalletKitConfigImpl: WalletKitConfig {
       documentSpecificRules: [
         DocumentTypeIdentifier.mDocPid: DocumentIssuanceRule(
           policy: .oneTimeUse,
-          numberOfCredentials: 10
+          numberOfCredentials: 2
         ),
         DocumentTypeIdentifier.sdJwtPid: DocumentIssuanceRule(
           policy: .oneTimeUse,
-          numberOfCredentials: 10
+          numberOfCredentials: 2
         )
       ]
     )

--- a/Modules/logic-core/Sources/Controller/WalletKitController.swift
+++ b/Modules/logic-core/Sources/Controller/WalletKitController.swift
@@ -81,6 +81,7 @@ public protocol WalletKitController: Sendable {
   func removeRevokedDocument(with id: String) async throws
 
   func getDocumentStatus(for statusIdentifier: StatusIdentifier) async throws -> CredentialStatus
+  func isDocumentLowOnCredentials(document: DocClaimsDecodable?) -> Bool
 }
 
 final class WalletKitControllerImpl: WalletKitController {
@@ -314,6 +315,14 @@ final class WalletKitControllerImpl: WalletKitController {
         )
       default: return nil
       }
+    }
+  }
+
+  func isDocumentLowOnCredentials(document: DocClaimsDecodable?) -> Bool {
+    if let document, let documentRemainingCredentials = document.credentialsUsageCounts?.remaining {
+      return document.credentialPolicy == CredentialPolicy.oneTimeUse && documentRemainingCredentials <= 1
+    } else {
+      return false
     }
   }
 

--- a/Modules/logic-core/Sources/Extension/WalletStorage.Document+Extensions.swift
+++ b/Modules/logic-core/Sources/Extension/WalletStorage.Document+Extensions.swift
@@ -39,7 +39,9 @@ extension WalletStorage.Document {
       credentialIssuerIdentifier: metadata?.credentialIssuerIdentifier,
       configurationIdentifier: metadata?.configurationIdentifier,
       validFrom: nil,
-      validUntil: nil
+      validUntil: nil,
+      credentialsUsageCounts: nil,
+      credentialPolicy: .oneTimeUse
     )
   }
 }

--- a/Modules/logic-core/Sources/Model/DeferrredDocument.swift
+++ b/Modules/logic-core/Sources/Model/DeferrredDocument.swift
@@ -33,4 +33,5 @@ public struct DeferrredDocument: DocClaimsDecodable {
   public var validUntil: Date?
   public var secureAreaName: String?
   public var credentialsUsageCounts: MdocDataModel18013.CredentialsUsageCounts?
+  public var credentialPolicy: MdocDataModel18013.CredentialPolicy
 }

--- a/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
+++ b/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
@@ -261,6 +261,7 @@ public enum LocalizableStringKey: Equatable, Sendable {
   case documentDetailsDocumentCredentialsExpandedButtonHideText
   case documentsListCredentialsUsageText([String])
   case expandableDocumentCredentialsIssueButton
+  case issuanceAddDocumentNoOptions
 }
 
 public extension LocalizableStringKey {

--- a/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
+++ b/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
@@ -260,6 +260,7 @@ public enum LocalizableStringKey: Equatable, Sendable {
   case documentDetailsDocumentCredentialsExpandedTextSubtitle
   case documentDetailsDocumentCredentialsExpandedButtonHideText
   case documentsListCredentialsUsageText([String])
+  case expandableDocumentCredentialsUpdateButton
 }
 
 public extension LocalizableStringKey {

--- a/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
+++ b/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
@@ -260,7 +260,7 @@ public enum LocalizableStringKey: Equatable, Sendable {
   case documentDetailsDocumentCredentialsExpandedTextSubtitle
   case documentDetailsDocumentCredentialsExpandedButtonHideText
   case documentsListCredentialsUsageText([String])
-  case expandableDocumentCredentialsUpdateButton
+  case expandableDocumentCredentialsIssueButton
 }
 
 public extension LocalizableStringKey {

--- a/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
+++ b/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
@@ -520,8 +520,8 @@ final class LocalizableManager: LocalizableManagerType {
       bundle.localizedString(forKey: "document_details_document_credentials_expanded_button_hide_text")
     case .documentsListCredentialsUsageText(let args):
       bundle.localizedStringWithArguments(forKey: "documents_list_credentials_usage_text", arguments: args)
-    case .expandableDocumentCredentialsUpdateButton:
-      bundle.localizedString(forKey: "expandable_document_credentials_update_button")
+    case .expandableDocumentCredentialsIssueButton:
+      bundle.localizedString(forKey: "expandable_document_credentials_issue_button")
     }
   }
 }

--- a/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
+++ b/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
@@ -520,6 +520,8 @@ final class LocalizableManager: LocalizableManagerType {
       bundle.localizedString(forKey: "document_details_document_credentials_expanded_button_hide_text")
     case .documentsListCredentialsUsageText(let args):
       bundle.localizedStringWithArguments(forKey: "documents_list_credentials_usage_text", arguments: args)
+    case .expandableDocumentCredentialsUpdateButton:
+      bundle.localizedString(forKey: "expandable_document_credentials_update_button")
     }
   }
 }

--- a/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
+++ b/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
@@ -522,6 +522,8 @@ final class LocalizableManager: LocalizableManagerType {
       bundle.localizedStringWithArguments(forKey: "documents_list_credentials_usage_text", arguments: args)
     case .expandableDocumentCredentialsIssueButton:
       bundle.localizedString(forKey: "expandable_document_credentials_issue_button")
+    case .issuanceAddDocumentNoOptions:
+      bundle.localizedString(forKey: "issuance_add_document_no_options")
     }
   }
 }

--- a/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
+++ b/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
@@ -1060,6 +1060,17 @@
         }
       }
     },
+    "issuance_add_document_no_options" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No available documents"
+          }
+        }
+      }
+    },
     "issuance_code_caption" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
+++ b/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
@@ -785,6 +785,17 @@
         }
       }
     },
+    "expandable_document_credentials_update_button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update now"
+          }
+        }
+      }
+    },
     "expiration_period" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
+++ b/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
@@ -785,13 +785,13 @@
         }
       }
     },
-    "expandable_document_credentials_update_button" : {
+    "expandable_document_credentials_issue_button" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Update now"
+            "value" : "Issue new"
           }
         }
       }

--- a/Modules/logic-ui/Sources/DesignSystem/Component/List/WrapListItemView.swift
+++ b/Modules/logic-ui/Sources/DesignSystem/Component/List/WrapListItemView.swift
@@ -107,7 +107,7 @@ public struct WrapListItemView: View {
               HStack(spacing: SPACING_SMALL) {
                 Text(text)
                   .font(Theme.shared.font.bodySmall.font)
-                  .foregroundColor(color)
+                  .foregroundColor(Theme.shared.color.onSurfaceVariant)
                   .lineLimit(1)
                   .multilineTextAlignment(.trailing)
                   .gone(if: text.toString.isEmpty)

--- a/Modules/logic-ui/Sources/DesignSystem/Component/Wrap/WrapButtonView.swift
+++ b/Modules/logic-ui/Sources/DesignSystem/Component/Wrap/WrapButtonView.swift
@@ -115,7 +115,9 @@ public struct WrapButtonView: View {
           }
         }
         .padding()
-        .frame(maxWidth: .infinity)
+        .if(gravity != .none) {
+          $0.frame(maxWidth: .infinity)
+        }
         .background(backgroundColor)
         .cornerRadius(cornerRadius)
         .overlay(
@@ -134,7 +136,7 @@ public struct WrapButtonView: View {
 
 public extension WrapButtonView {
   enum Gravity {
-    case center, start, end
+    case center, start, end, none
   }
 }
 

--- a/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
@@ -3578,6 +3578,16 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             defaultCall: await __defaultImplStub!.getDocumentStatus(for: p0)
         )
     }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return cuckoo_manager.call(
+            "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+            parameters: (p0),
+            escapingParameters: (p0),
+            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isDocumentLowOnCredentials(document: p0)
+        )
+    }
 
     public struct __StubbingProxy_WalletKitController: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
@@ -3874,6 +3884,14 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
             let matchers: [Cuckoo.ParameterMatcher<(StatusIdentifier)>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
                 method: "getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus",
+                parameterMatchers: matchers
+            ))
+        }
+        
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.ProtocolStubFunction<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
+                method: "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -4325,6 +4343,18 @@ errorType: Error.self,            superclassCall: Cuckoo.MockManager.crashOnProt
                 sourceLocation: sourceLocation
             )
         }
+        
+        
+        @discardableResult
+        func isDocumentLowOnCredentials<M1: Cuckoo.OptionalMatchable>(document p0: M1) -> Cuckoo.__DoNotUse<(DocClaimsDecodable?), Bool> where M1.OptionalMatchedType == DocClaimsDecodable {
+            let matchers: [Cuckoo.ParameterMatcher<(DocClaimsDecodable?)>] = [wrap(matchable: p0) { $0 }]
+            return cuckoo_manager.verify(
+                "isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool",
+                callMatcher: callMatcher,
+                parameterMatchers: matchers,
+                sourceLocation: sourceLocation
+            )
+        }
     }
 }
 
@@ -4480,6 +4510,10 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
     
     public func getDocumentStatus(for p0: StatusIdentifier) async throws -> CredentialStatus {
         return DefaultValueRegistry.defaultValue(for: (CredentialStatus).self)
+    }
+    
+    public func isDocumentLowOnCredentials(document p0: DocClaimsDecodable?) -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 


### PR DESCRIPTION
# Description of changes

- Removed from the Settings View the switch button for showing/hiding the batch issuance counter. Now it will always be visible, both in the Documents Tab and in the Document Details View.
- Add Document Screen now has a parameter in the enum to filter the add document list.
- If the Add Document View gets loaded with IssuanceFlowUiConfig.ExtraDocument and its filterType is not null and match some of the Issuer's supported documents, then only those documents will be displayed on its list. Existing functionality to also filter and show only the PIDs if the screen was loaded with IssuanceFlowUiConfig.NoDocument remains unchanged.
- In the Documents Tab, if a document is running out of credentials (<=1 and its policy is OneTimeUse) then a warning icon will be displayed.
- For the same scenario, in the Document Details View, the Credential Info section will be expanded by default (otherwise it will be collapsed) and it will also show a "Issue new" button(otherwise it will not be shown at all). Upon clicking it the User will be navigated to the Add Documents View with only this document displayed in its list.
- Batch counter has been removed from the PrefKeys. All related strings, usages and dependencies have also been removed.
- Navigation to the Add Document Screen has been updated and adjusted across the whole project.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [x] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable
