### PR TITLE
feat: option to change issuer while issuing new documents

### DIFF
--- a/Modules/feature-common/Sources/UI/QuickPin/QuickPinViewModel.swift
+++ b/Modules/feature-common/Sources/UI/QuickPin/QuickPinViewModel.swift
@@ -66,7 +66,7 @@ final class QuickPinViewModel<Router: RouterHost>: ViewModel<Router, QuickPinSta
         success: config.isSetFlow ? .quickPinSetSuccess : .quickPinUpdateSuccess,
         successButton: config.isSetFlow ? .quickPinSetSuccessButton : .quickPinUpdateSuccessButton,
         successNavigationType: config.isSetFlow
-        ? .push(screen: .featureIssuanceModule(.issuanceAddDocument(config: IssuanceFlowUiConfig(flow: .noDocument))))
+        ? .push(screen: .featureDashboardModule(.dashboard))
         : .pop(screen: .featureDashboardModule(.dashboard)),
         isCancellable: config.isUpdateFlow,
         pinError: nil,

--- a/Modules/feature-dashboard/Sources/Router/DashboardRouter.swift
+++ b/Modules/feature-dashboard/Sources/Router/DashboardRouter.swift
@@ -96,6 +96,12 @@ public final class DashboardRouter {
           transactionId: id
         )
       ).eraseToAnyView()
+    case .issuerSelection:
+      IssuerSelectionView(
+        viewModel: .init(
+          router: host
+        )
+      ).eraseToAnyView()
     }
   }
 }

--- a/Modules/feature-dashboard/Sources/UI/Issuance/IssuerInfo.swift
+++ b/Modules/feature-dashboard/Sources/UI/Issuance/IssuerInfo.swift
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+import Foundation
+
+struct IssuerInfo: Equatable, Codable {
+  let name: String
+  let url: String
+}

--- a/Modules/feature-dashboard/Sources/UI/Issuance/IssuerManager.swift
+++ b/Modules/feature-dashboard/Sources/UI/Issuance/IssuerManager.swift
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+import Foundation
+import UIKit
+import OpenID4VCI
+
+@MainActor
+class IssuerManager {
+  static let shared = IssuerManager()
+
+  private let userDefaults = UserDefaults.standard
+  private let issuersKey = "storedIssuers"
+  private let selectedIssuerKey = "selectedIssuer"
+  private let selectedIssuerUrlKey = "selectedIssuerUrl"
+
+  private let defaultIssuers: [IssuerInfo] = [
+    IssuerInfo(
+      name: "EUDI Issuer",
+      url: "https://issuer.eudiw.dev"
+    ),
+    IssuerInfo(
+      name: "RDW Issuer",
+      url: "https://mdlissuer.azurewebsites.net"
+    )
+  ]
+
+  var defaultIssuerName: String {
+    return defaultIssuers.first?.name ?? ""
+  }
+
+  private init() {
+    if getIssuers().isEmpty {
+      for _ in defaultIssuers {
+        addIssuer(defaultIssuers.first?.name ?? "", url: defaultIssuers.first?.url ?? "")
+      }
+    }
+  }
+
+  func getIssuers() -> [IssuerInfo] {
+    var issuers: [IssuerInfo]
+    if let data = userDefaults.data(forKey: issuersKey),
+       let storedIssuers = try? JSONDecoder().decode([IssuerInfo].self, from: data) {
+      issuers = storedIssuers
+    } else {
+      issuers = []
+    }
+
+    if !issuers.contains(defaultIssuers) {
+      issuers.insert(contentsOf: defaultIssuers, at: 0)
+    }
+    return issuers
+  }
+
+  func getSelectedIssuer() -> String? {
+    return userDefaults.string(forKey: selectedIssuerKey)
+  }
+
+  private func getFirstIssuer(storedName: String?, storedUrl: String?, newIssuer: IssuerInfo, defaultIssuer: IssuerInfo) -> Bool {
+    let isFreshInstall = storedName == nil && storedUrl == nil
+    let isDefaultSelection = newIssuer.name == defaultIssuer.name && newIssuer.url == defaultIssuer.url
+    return isFreshInstall && isDefaultSelection
+  }
+
+  func setSelectedIssuer(_ name: String) {
+    guard let newIssuer = getIssuers().first(where: { $0.name == name }) else { return }
+
+    let defaultIssuer = defaultIssuers[0]
+
+    let storedName = userDefaults.string(forKey: selectedIssuerKey)
+    let storedUrl = userDefaults.string(forKey: selectedIssuerUrlKey)
+
+    let currentName = storedName ?? defaultIssuer.name
+    let currentUrl = storedUrl ?? defaultIssuer.url
+
+    guard currentName != newIssuer.name || currentUrl != newIssuer.url else { return }
+
+    userDefaults.set(newIssuer.name, forKey: selectedIssuerKey)
+    userDefaults.set(newIssuer.url, forKey: selectedIssuerUrlKey)
+
+    if !getFirstIssuer(storedName: storedName, storedUrl: storedUrl, newIssuer: newIssuer, defaultIssuer: defaultIssuer) {
+      showIssuerChangedAlert()
+    }
+  }
+
+  func addIssuer(_ name: String, url: String) {
+    var issuers = getIssuers()
+    let newIssuer = IssuerInfo(name: name, url: url)
+
+    if !issuers.contains(newIssuer) {
+      issuers.append(newIssuer)
+      if let encoded = try? JSONEncoder().encode(issuers) {
+        userDefaults.set(encoded, forKey: issuersKey)
+      }
+    }
+  }
+
+  func removeIssuer(_ name: String) {
+    var issuers = getIssuers()
+    issuers.removeAll { $0.name == name }
+    if let encoded = try? JSONEncoder().encode(issuers) {
+      userDefaults.set(encoded, forKey: issuersKey)
+    }
+    if getSelectedIssuer() == name {
+      setSelectedIssuer(defaultIssuers.first?.name ?? "")
+    }
+  }
+
+  private func showIssuerChangedAlert() {
+    let alert = UIAlertController(
+      title: "Issuer Changed",
+      message: "The app needs to restart to apply the new issuer configuration. The app will close now, please reopen it.",
+      preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+    alert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+      exit(0)
+    })
+
+    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+       let rootVC = windowScene.windows.first?.rootViewController {
+      rootVC.present(alert, animated: true)
+    }
+  }
+}

--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -25,6 +25,10 @@ struct VciConfig: Sendable {
   public let useDPoP: Bool
 }
 
+private enum UserDefaultsKeys {
+  static let selectedIssuerUrl = "selectedIssuerUrl"
+}
+
 struct ReaderConfig: Sendable {
   public let trustedCerts: [Data]
 }
@@ -98,7 +102,8 @@ struct WalletKitConfigImpl: WalletKitConfig {
     return switch configLogic.appBuildVariant {
     case .DEMO:
         .init(
-          issuerUrl: "https://issuer.eudiw.dev",
+          issuerUrl: UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedIssuerUrl) ??
+          "https://issuer.eudiw.dev",
           clientId: "wallet-dev",
           redirectUri: URL(string: "eu.europa.ec.euidi://authorization")!,
           usePAR: true,
@@ -106,7 +111,8 @@ struct WalletKitConfigImpl: WalletKitConfig {
         )
     case .DEV:
         .init(
-          issuerUrl: "https://dev.issuer.eudiw.dev",
+          issuerUrl: UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedIssuerUrl) ??
+          "https://dev.issuer.eudiw.dev",
           clientId: "wallet-dev",
           redirectUri: URL(string: "eu.europa.ec.euidi://authorization")!,
           usePAR: true,

--- a/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
+++ b/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
@@ -260,6 +260,7 @@ public enum LocalizableStringKey: Equatable, Sendable {
   case documentDetailsDocumentCredentialsExpandedTextSubtitle
   case documentDetailsDocumentCredentialsExpandedButtonHideText
   case documentsListCredentialsUsageText([String])
+  case selectIssuer
 }
 
 public extension LocalizableStringKey {

--- a/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
+++ b/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
@@ -520,6 +520,8 @@ final class LocalizableManager: LocalizableManagerType {
       bundle.localizedString(forKey: "document_details_document_credentials_expanded_button_hide_text")
     case .documentsListCredentialsUsageText(let args):
       bundle.localizedStringWithArguments(forKey: "documents_list_credentials_usage_text", arguments: args)
+    case .selectIssuer:
+      bundle.localizedString(forKey: "select_issuer")
     }
   }
 }

--- a/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
+++ b/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
@@ -2119,6 +2119,17 @@
         }
       }
     },
+    "select_issuer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose the issuer"
+            }
+          }
+        }
+    },
     "settings_menu" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modules/logic-ui/Sources/Navigation/AppRoute.swift
+++ b/Modules/logic-ui/Sources/Navigation/AppRoute.swift
@@ -60,6 +60,7 @@ public enum FeatureDashboardRouteModule: AppRouteModule {
   case issuanceOption
   case documentDetails(id: String)
   case transactionDetails(id: String)
+  case issuerSelection(String)
 
   public var info: (key: String, arguments: [String: String]) {
     return switch self {
@@ -77,6 +78,8 @@ public enum FeatureDashboardRouteModule: AppRouteModule {
       (key: "DocumentDetails", arguments: ["id": id])
     case .transactionDetails(let id):
       (key: "TransactionDetails", arguments: ["id": id])
+    case .issuerSelection:
+      (key: "issuerSelection", arguments: [:])
     }
   }
 }


### PR DESCRIPTION
# Description of changes
option to change issuer while issuing new documents

### UI:
| `+` on top right | choose issuer screen | restart app warning |
--|--|--
| <img width="828" height="1792" alt="Screenshot 2025-08-01 at 12 29 26" src="https://github.com/user-attachments/assets/0230f246-522d-4305-a4ac-78e68811539a" /> | <img width="828" height="1792" alt="Screenshot 2025-08-01 at 12 29 35" src="https://github.com/user-attachments/assets/f88e868f-a24e-4018-93e9-bb7414ed0bda" /> | <img width="828" height="1792" alt="Screenshot 2025-08-01 at 12 29 39" src="https://github.com/user-attachments/assets/8a068129-53de-469b-aeea-bbe86bac3cc0" /> |



## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Test suite run successfully

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable
