### PR TITLE
Robustly determine keychain access group

### DIFF
--- a/Modules/logic-business/Sources/Extension/Bundle+Extensions.swift
+++ b/Modules/logic-business/Sources/Extension/Bundle+Extensions.swift
@@ -53,52 +53,49 @@ public extension Bundle {
     return "\(mainAppBundleID).eudi.document.storage"
   }
 
-  /// Gets the keychain access group based on the main app bundle identifier.
-  /// This tries to read the access group from an existing keychain item first.
-  /// If no items exist, it constructs the access group from the bundle identifier.
-  /// Always returns a non-nil value to ensure compatibility with APIs that require it.
+  /// Gets the keychain access group by writing a temporary probe item and reading back the
+  /// access group the OS assigned. When no `kSecAttrAccessGroup` is specified, the OS places
+  /// the item in the app's default keychain group, which is the first entry in the
+  /// `keychain-access-groups` entitlement — already fully resolved by Xcode (e.g.
+  /// `AZXQE7588Y.eu.europa.ec.euidi.dev`). This works correctly on both simulator and device.
   static func getKeychainAccessGroup() -> String {
-    // Try to read ANY existing keychain item to get the access group
-    // This is safer than trying to create an item, which requires proper entitlements
-    let query: [String: Any] = [
+    let probeAccount = "eu.europa.ec.euidi.access.group.probe"
+
+    let deleteQuery: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: probeAccount
+    ]
+    SecItemDelete(deleteQuery as CFDictionary)
+
+    let addQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: probeAccount,
+      kSecValueData as String: Data("probe".utf8)
+    ]
+
+    guard SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess else {
+      return getMainAppBundleID()
+    }
+
+    let readQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: probeAccount,
       kSecMatchLimit as String: kSecMatchLimitOne,
       kSecReturnAttributes as String: true
     ]
 
     var result: CFTypeRef?
-    let status = SecItemCopyMatching(query as CFDictionary, &result)
-
-    // If we found an existing item, read its access group
-    if status == errSecSuccess,
+    let accessGroup: String
+    if SecItemCopyMatching(readQuery as CFDictionary, &result) == errSecSuccess,
        let attributes = result as? [String: Any],
-       let accessGroup = attributes[kSecAttrAccessGroup as String] as? String,
-       !accessGroup.isEmpty {
-      return accessGroup
+       let group = attributes[kSecAttrAccessGroup as String] as? String,
+       !group.isEmpty {
+      accessGroup = group
+    } else {
+      accessGroup = getMainAppBundleID()
     }
 
-    // If no existing items found, construct the access group from bundle identifier
-    // The access group format in entitlements is: $(AppIdentifierPrefix){BundleID}
-    // At runtime, we need to construct: {TeamID}.{BundleID}
-    // We'll use the main app bundle ID as the base
-    let mainAppBundleID = getMainAppBundleID()
-
-    // Try to extract team ID from the current bundle identifier
-    // Some bundle IDs include the team ID as a prefix: {TeamID}.{BundleID}
-    if let bundleID = Bundle.main.bundleIdentifier {
-      let components = bundleID.split(separator: ".")
-
-      // Check if first component looks like a team ID (typically 10 characters, alphanumeric)
-      if components.count > 2,
-         let firstComponent = components.first,
-         firstComponent.count == 10,
-         firstComponent.allSatisfy({ $0.isLetter || $0.isNumber }) {
-        // Construct access group with team ID prefix
-        return "\(firstComponent).\(mainAppBundleID)"
-      }
-    }
-
-    // Fallback: return the team ID and main app bundle ID as the access group
-    return "\("Team ID".valueFromBundle).\(mainAppBundleID)"
+    SecItemDelete(deleteQuery as CFDictionary)
+    return accessGroup
   }
 }


### PR DESCRIPTION
## Type of change

Implement a probe technique to determine the keychain access group by writing and reading back a temporary item. This allows the OS to provide the fully resolved access group from the app's entitlements, replacing the previous manual construction logic which could be unreliable across different environments.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable
