### PR TITLE
Handle error state in request authorization view

### DIFF
--- a/EudiReferenceWalletIDProvider/UI/Authorization/RequestAuthorizationView.swift
+++ b/EudiReferenceWalletIDProvider/UI/Authorization/RequestAuthorizationView.swift
@@ -29,7 +29,7 @@ struct RequestAuthorizationView: View {
   var body: some View {
     NavigationStack {
       VStack(alignment: .center) {
-        if !viewModel.viewState.items.isEmpty {
+        if !viewModel.viewState.items.isEmpty, viewModel.viewState.errorMessage == nil {
           contentView(viewState: viewModel.viewState)
         } else {
           noDocumentsFound()


### PR DESCRIPTION
## Type of change

Ensure the view displays the "no documents found" state if an error message is present, even if the items list is not empty. This improves error handling consistency for the DC API.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable
