### PR TITLE
Update EUDI dependencies and migrate to WalletKit TrustConfiguration API

### DIFF
--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "543b61a601fdc2083c325d77b3c5afaaa81a2547",
-        "version" : "0.35.1"
+        "revision" : "181a53cbefaf533f55daf90a8717d9970b9744b6",
+        "version" : "0.35.2"
       }
     },
     {

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "60a7cebdf269aedcb56ab7db505d5d2ac9f13c70a556e5d52236b45629e6bcf5",
+  "originHash" : "a597fc306027c814a27c90141d4a9f72602cebbdbb0e2cae6f46ee0a6d2de08b",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "a8e416f490ee1d00ad9255ee867010adf409e017",
-        "version" : "0.23.0"
+        "revision" : "809bba77f41a3687136b00729b82d54a13adb0b2",
+        "version" : "0.23.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "aa10d0364de3874bd24104539cf95d10dc1f552e",
-        "version" : "0.23.3"
+        "revision" : "4d7b7286c504ce949b9cbb5e3b16cec3679c1559",
+        "version" : "0.23.4"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "87127acec21251d975d3a2af7f065b323f3bd0ec",
-        "version" : "0.23.3"
+        "revision" : "2664f2b13d375d25c5be9f13b89724d45842a4fe",
+        "version" : "0.23.4"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "926124c528b2c3217d4f0d2942c45b3fbb0803eb",
-        "version" : "0.37.1"
+        "revision" : "215ea7ade8f00146e3079b6b41961c963d1de7b1",
+        "version" : "0.37.2"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "292d54ccc55a8e2acb9ed1541518371c92eef265",
-        "version" : "0.23.0"
+        "revision" : "3abd8e54a0576d4114b78672e03c22d3613b5044",
+        "version" : "0.23.1"
       }
     },
     {

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "67bc2b28d52bab7e781abfc56710239328e68634e15841e9c081af791bce2bfc",
+  "originHash" : "4350b7c8fde93e273a29158cf5b0b4d815a11b260d0fe519a32a2face722cd9f",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "43ecf21f3ffc10417dcbb543581628c6ded150f9",
-        "version" : "0.36.1"
+        "revision" : "73a91d142855b154fdecd9201ddb08cc65d6a51c",
+        "version" : "0.36.2"
       }
     },
     {

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4350b7c8fde93e273a29158cf5b0b4d815a11b260d0fe519a32a2face722cd9f",
+  "originHash" : "60a7cebdf269aedcb56ab7db505d5d2ac9f13c70a556e5d52236b45629e6bcf5",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "2c7fbe4ae08dcc8de06312b2fc9cf9bf461e60fe",
-        "version" : "0.23.2"
+        "revision" : "aa10d0364de3874bd24104539cf95d10dc1f552e",
+        "version" : "0.23.3"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "73a91d142855b154fdecd9201ddb08cc65d6a51c",
-        "version" : "0.36.2"
+        "revision" : "926124c528b2c3217d4f0d2942c45b3fbb0803eb",
+        "version" : "0.37.1"
       }
     },
     {

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c23452600dba1a320c07f135406ae287bae3d9b4df0e55db955e892670d1b13",
+  "originHash" : "67bc2b28d52bab7e781abfc56710239328e68634e15841e9c081af791bce2bfc",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "af8af959a8113bd27c4b457e70480e765498de08",
-        "version" : "0.22.1"
+        "revision" : "a8e416f490ee1d00ad9255ee867010adf409e017",
+        "version" : "0.23.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "f5429d517115602274242ab2d420ad42af3c3681",
-        "version" : "0.23.0"
+        "revision" : "2c7fbe4ae08dcc8de06312b2fc9cf9bf461e60fe",
+        "version" : "0.23.2"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "cbf4820ea044b3eaa618db61cc48990406fe8f66",
-        "version" : "0.23.1"
+        "revision" : "87127acec21251d975d3a2af7f065b323f3bd0ec",
+        "version" : "0.23.3"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift.git",
       "state" : {
-        "revision" : "1f1956b028e9819b6f6be29b60ccf2711c6788ad",
-        "version" : "0.35.0"
+        "revision" : "dab5e244bf34efcb294711844527b1124c1e9257",
+        "version" : "0.35.1"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "ce244c57dd333a8d18531397301df7c20606f367",
-        "version" : "0.36.0"
+        "revision" : "43ecf21f3ffc10417dcbb543581628c6ded150f9",
+        "version" : "0.36.1"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "c1a1ee78c889dff33544a0771345f3c920ae05da",
-        "version" : "0.22.1"
+        "revision" : "292d54ccc55a8e2acb9ed1541518371c92eef265",
+        "version" : "0.23.0"
       }
     },
     {

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5413fd29b3ef46289fbe4f8f8d7f7bfff02c7d1d47d4da68c98db6dc824955ea",
+  "originHash" : "ed4e796349f341b3851b0648ac9870eb8b17b44ab24fd1b4a542bfdd1fbe02e4",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "bd3709d260cb82b01f357b6e659a725b0868f40b",
-        "version" : "0.21.2"
+        "revision" : "af8af959a8113bd27c4b457e70480e765498de08",
+        "version" : "0.22.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "6791ef396ab19e1e263ed8b1410e3dfdc043d8c9",
-        "version" : "0.22.0"
+        "revision" : "f5429d517115602274242ab2d420ad42af3c3681",
+        "version" : "0.23.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "8f5ab811960731ac049dc0d0f3e9e780bdcf7a46",
-        "version" : "0.22.0"
+        "revision" : "cbf4820ea044b3eaa618db61cc48990406fe8f66",
+        "version" : "0.23.1"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "b0312fbd037f2cbea5064c939f8d80c56ceed2e7",
-        "version" : "0.34.4"
+        "revision" : "543b61a601fdc2083c325d77b3c5afaaa81a2547",
+        "version" : "0.35.1"
       }
     },
     {
@@ -204,8 +204,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "763619eea0901c7a0e42700dbfb6abc25d7be676",
-        "version" : "0.22.0"
+        "revision" : "c1a1ee78c889dff33544a0771345f3c920ae05da",
+        "version" : "0.22.1"
+      }
+    },
+    {
+      "identity" : "eudi-lib-kmp-etsi-1196x2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-kmp-etsi-1196x2.git",
+      "state" : {
+        "revision" : "fe25f428471b88e975b6b07814162a2d14abbfe4",
+        "version" : "0.4.0-alpha.1-SPM"
       }
     },
     {
@@ -429,8 +438,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/niscy-eudiw/SwiftCBOR.git",
       "state" : {
-        "revision" : "a663e7a6bd50d2224223ed60622b531b18499dd0",
-        "version" : "0.6.4"
+        "revision" : "e8fef8613a4c32b150885fec8f32c2ebfe0501c4",
+        "version" : "0.6.5"
       }
     },
     {

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed4e796349f341b3851b0648ac9870eb8b17b44ab24fd1b4a542bfdd1fbe02e4",
+  "originHash" : "3c23452600dba1a320c07f135406ae287bae3d9b4df0e55db955e892670d1b13",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "fdc9c9de49c631049af8e8b6b5734f8c5923f6c4",
-        "version" : "0.41.0"
+        "revision" : "bdd143c859c213c9041c47fb53d8009d1f33e0b9",
+        "version" : "0.50.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "181a53cbefaf533f55daf90a8717d9970b9744b6",
-        "version" : "0.35.2"
+        "revision" : "ce244c57dd333a8d18531397301df7c20606f367",
+        "version" : "0.36.0"
       }
     },
     {

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a597fc306027c814a27c90141d4a9f72602cebbdbb0e2cae6f46ee0a6d2de08b",
+  "originHash" : "b5ee709a8b5c8e5f4b3dab4b298bee67acb55a8ef350d835cd83d5cd4f1f8880",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "4d7b7286c504ce949b9cbb5e3b16cec3679c1559",
-        "version" : "0.23.4"
+        "revision" : "f20e82fc0a6522ce2bae4f73abef99c51963a344",
+        "version" : "0.23.5"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "2664f2b13d375d25c5be9f13b89724d45842a4fe",
-        "version" : "0.23.4"
+        "revision" : "a4c3bb177f5a27e77ad6eb48375f91271a952043",
+        "version" : "0.23.5"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "215ea7ade8f00146e3079b6b41961c963d1de7b1",
-        "version" : "0.37.2"
+        "revision" : "c5ecc2dc89d713fd212014a37970c37b8be73699",
+        "version" : "0.37.3"
       }
     },
     {

--- a/Modules/feature-common/Sources/UI/Request/BaseRequestView.swift
+++ b/Modules/feature-common/Sources/UI/Request/BaseRequestView.swift
@@ -86,6 +86,13 @@ public struct BaseRequestView<Router: RouterHost>: View {
         Button(.okButton) {}
       }
     )
+    .sheetDialog(isPresented: $viewModel.isVerifierNotTrustedSheetShowing) {
+      TrustBlockedSheetContent(
+        title: .presentationBlockedTitle,
+        message: .presentationBlockedMessage,
+        onClose: { viewModel.onVerifierNotTrustedClose() }
+      )
+    }
   }
 }
 

--- a/Modules/feature-common/Sources/UI/Request/BaseRequestViewModel.swift
+++ b/Modules/feature-common/Sources/UI/Request/BaseRequestViewModel.swift
@@ -41,6 +41,7 @@ open class BaseRequestViewModel<Router: RouterHost>: ViewModel<Router, RequestVi
 
   var isRequestInfoModalShowing: Bool = false
   var isVerifiedEntityModalShowing: Bool = false
+  var isVerifierNotTrustedSheetShowing: Bool = false
   var itemsChanged: Bool = false
 
   public init(router: Router, originator: AppRoute) {
@@ -249,6 +250,20 @@ open class BaseRequestViewModel<Router: RouterHost>: ViewModel<Router, RequestVi
 
   func onVerifiedEntityModal() {
     isVerifiedEntityModalShowing = !isVerifiedEntityModalShowing
+  }
+
+  open func stopPresentation() async {}
+  public func onVerifierNotTrusted() {
+    setState {
+      $0.copy(isLoading: false, initialized: true).copy(error: nil)
+    }
+    isVerifierNotTrustedSheetShowing = true
+    Task { await stopPresentation() }
+  }
+
+  func onVerifierNotTrustedClose() {
+    isVerifierNotTrustedSheetShowing = false
+    onPop()
   }
 
   func onSelectionChanged(id: String) async {

--- a/Modules/feature-common/Tests/Extension/TestErrorIssuerTrust.swift
+++ b/Modules/feature-common/Tests/Extension/TestErrorIssuerTrust.swift
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+import XCTest
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_test
+@testable import feature_test
+
+final class TestErrorIssuerTrust: EudiTest {
+
+  // MARK: - WalletError
+
+  func testIsIssuerNotTrusted_whenWalletErrorTrustError_thenReturnsTrue() {
+    let error: Error = WalletError(description: "trust", code: .trustError)
+    XCTAssertTrue(error.isIssuerNotTrusted)
+  }
+
+  func testIsIssuerNotTrusted_whenWalletErrorOtherCode_thenReturnsFalse() {
+    let error: Error = WalletError(description: "boom", code: .internalError)
+    XCTAssertFalse(error.isIssuerNotTrusted)
+  }
+
+  func testIsIssuerNotTrusted_whenWalletErrorNotSecuredRequest_thenReturnsFalse() {
+    // `.notSecuredRequest` is a distinct code from `.trustError`; only `.trustError`
+    // maps to an untrusted issuer.
+    let error: Error = WalletError(description: "not secured", code: .notSecuredRequest)
+    XCTAssertFalse(error.isIssuerNotTrusted)
+  }
+
+  // MARK: - MsoValidationError
+
+  func testIsIssuerNotTrusted_whenMsoIssuerTrustFailed_thenReturnsTrue() {
+    let error: Error = MsoValidationError.issuerTrustFailed("untrusted issuer")
+    XCTAssertTrue(error.isIssuerNotTrusted)
+  }
+
+  func testIsIssuerNotTrusted_whenMsoOtherCase_thenReturnsFalse() {
+    let error: Error = MsoValidationError.signatureVerificationFailed("bad signature")
+    XCTAssertFalse(error.isIssuerNotTrusted)
+  }
+
+  func testIsIssuerNotTrusted_whenMsoMultipleErrorsContainsTrustFailure_thenReturnsTrue() {
+    let error: Error = MsoValidationError.multipleErrors([
+      .signatureVerificationFailed("bad signature"),
+      .issuerTrustFailed("untrusted issuer")
+    ])
+    XCTAssertTrue(error.isIssuerNotTrusted)
+  }
+
+  func testIsIssuerNotTrusted_whenMsoMultipleErrorsNoTrustFailure_thenReturnsFalse() {
+    let error: Error = MsoValidationError.multipleErrors([
+      .signatureVerificationFailed("bad signature"),
+      .validityInfo("expired")
+    ])
+    XCTAssertFalse(error.isIssuerNotTrusted)
+  }
+
+  func testIsIssuerNotTrusted_whenMsoMultipleErrorsEmpty_thenReturnsFalse() {
+    let error: Error = MsoValidationError.multipleErrors([])
+    XCTAssertFalse(error.isIssuerNotTrusted)
+  }
+
+  func testIsIssuerNotTrusted_whenMsoNestedMultipleErrorsContainsTrustFailure_thenReturnsTrue() {
+    // Exercises the recursive walk through nested `.multipleErrors`.
+    let error: Error = MsoValidationError.multipleErrors([
+      .multipleErrors([
+        .validityInfo("expired"),
+        .issuerTrustFailed("untrusted issuer")
+      ])
+    ])
+    XCTAssertTrue(error.isIssuerNotTrusted)
+  }
+
+  // MARK: - Unrelated errors
+
+  func testIsIssuerNotTrusted_whenGenericError_thenReturnsFalse() {
+    let error: Error = NSError(domain: "com.eudi.test", code: 1)
+    XCTAssertFalse(error.isIssuerNotTrusted)
+  }
+}

--- a/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
@@ -9279,6 +9279,22 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo
@@ -11237,6 +11253,21 @@ import logic_resources
 
 
 // MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/SearchableList/SearchableListView.swift'
+
+import Cuckoo
+import SwiftUI
+import logic_resources
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+
+
+
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
@@ -6213,7 +6213,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -6258,12 +6258,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -6354,8 +6354,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -6406,8 +6406,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -6454,9 +6454,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
@@ -11267,7 +11267,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
 
 import Cuckoo
 import SwiftUI
@@ -11282,7 +11282,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
+++ b/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
@@ -66,7 +66,7 @@ final actor DocumentDetailsInteractorImpl: DocumentDetailsInteractor {
       )
       return .success
     } catch {
-      return .failure(error)
+      return error.isIssuerNotTrusted ? .issuerNotTrusted : .failure(error)
     }
   }
 
@@ -152,5 +152,6 @@ public enum DocumentDetailsDeletionPartialState: Sendable {
 
 public enum DocumentDetailsReIssuancePartialState: Sendable {
   case success
+  case issuerNotTrusted
   case failure(Error)
 }

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsView.swift
@@ -90,6 +90,13 @@ struct DocumentDetailsView<Router: RouterHost>: View {
         }
       }
     )
+    .sheetDialog(isPresented: $viewModel.isIssuerNotTrustedSheetShowing) {
+      TrustBlockedSheetContent(
+        title: .issuanceBlockedTitle,
+        message: .issuanceBlockedMessage,
+        onClose: { viewModel.isIssuerNotTrustedSheetShowing = false }
+      )
+    }
     .task {
       await viewModel.fetchDocumentDetails()
     }

--- a/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsViewModel.swift
+++ b/Modules/feature-dashboard/Sources/UI/Detail/Document/DocumentDetailsViewModel.swift
@@ -35,6 +35,7 @@ struct DocumentDetailsViewState: ViewState {
 final class DocumentDetailsViewModel<Router: RouterHost>: ViewModel<Router, DocumentDetailsViewState> {
 
   var isDeletionModalShowing: Bool = false
+  var isIssuerNotTrustedSheetShowing: Bool = false
   var isVisible = true
   var showReissuanceDialog: Bool = false
   var showBookmarkAlert = false
@@ -131,6 +132,9 @@ final class DocumentDetailsViewModel<Router: RouterHost>: ViewModel<Router, Docu
       switch await interactor.reIssueDocument(identifier: viewState.documentId) {
       case .success:
         router.pop()
+      case .issuerNotTrusted:
+        setState { $0.copy(isLoading: false).copy(error: nil) }
+        isIssuerNotTrustedSheetShowing = true
       case .failure(let error):
         self.setState {
           $0.copy(

--- a/Modules/feature-dashboard/Tests/Interactor/TestDocumentDetailsInteractor.swift
+++ b/Modules/feature-dashboard/Tests/Interactor/TestDocumentDetailsInteractor.swift
@@ -428,6 +428,8 @@ final class TestDocumentDetailsInteractor: EudiTest {
     switch result {
     case .success:
       XCTAssertTrue(true)
+    case .issuerNotTrusted:
+      XCTFail("Expected success, got issuerNotTrusted")
     case .failure:
       XCTFail("Expected success, got failure")
     }
@@ -448,6 +450,8 @@ final class TestDocumentDetailsInteractor: EudiTest {
     switch result {
     case .success:
       XCTFail("Expected failure, got success")
+    case .issuerNotTrusted:
+      XCTFail("Expected failure, got issuerNotTrusted")
     case .failure(let error):
       XCTAssertEqual(
         error.localizedDescription,

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -12051,6 +12051,23 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_dashboard
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo
@@ -14072,6 +14089,22 @@ import logic_resources
 
 
 // MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/SearchableList/SearchableListView.swift'
+
+import Cuckoo
+import SwiftUI
+import logic_resources
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_dashboard
+
+
+
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -8970,7 +8970,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -9016,12 +9016,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -9112,8 +9112,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -9164,8 +9164,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -9212,9 +9212,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -14104,7 +14104,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
 
 import Cuckoo
 import SwiftUI
@@ -14120,7 +14120,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-issuance/Sources/Interactor/AddDocumentInteractor.swift
+++ b/Modules/feature-issuance/Sources/Interactor/AddDocumentInteractor.swift
@@ -200,7 +200,7 @@ final actor AddDocumentInteractorImpl: AddDocumentInteractor {
       }
 
     } catch {
-      return .failure(error)
+      return error.isIssuerNotTrusted ? .issuerNotTrusted : .failure(error)
     }
   }
 
@@ -226,7 +226,7 @@ final actor AddDocumentInteractorImpl: AddDocumentInteractor {
       }
 
     } catch {
-      return .failure(error)
+      return error.isIssuerNotTrusted ? .issuerNotTrusted : .failure(error)
     }
   }
 
@@ -258,6 +258,7 @@ public enum IssueResultPartialState: Sendable {
   case success([String])
   case deferredSuccess(ScopedDocument)
   case dynamicIssuance(RemoteSessionCoordinator)
+  case issuerNotTrusted
   case failure(Error)
 }
 
@@ -265,6 +266,7 @@ public enum IssueDynamicDocumentPartialState: Sendable {
   case success(String)
   case noPending
   case deferredSuccess
+  case issuerNotTrusted
   case failure(Error)
 }
 

--- a/Modules/feature-issuance/Sources/Interactor/DocumentOfferInteractor.swift
+++ b/Modules/feature-issuance/Sources/Interactor/DocumentOfferInteractor.swift
@@ -143,7 +143,7 @@ final actor DocumentOfferInteractorImpl: DocumentOfferInteractor {
       }
 
     } catch {
-      return .failure(error)
+      return error.isIssuerNotTrusted ? .issuerNotTrusted : .failure(error)
     }
   }
 
@@ -196,7 +196,7 @@ final actor DocumentOfferInteractorImpl: DocumentOfferInteractor {
       }
 
     } catch {
-      return .failure(error)
+      return error.isIssuerNotTrusted ? .issuerNotTrusted : .failure(error)
     }
   }
 
@@ -314,11 +314,13 @@ public enum OfferResultPartialState: Sendable {
   case partialSuccess(AppRoute)
   case deferredSuccess(AppRoute)
   case dynamicIssuance(RemoteSessionCoordinator)
+  case issuerNotTrusted
   case failure(Error)
 }
 
 public enum OfferDynamicIssuancePartialState: Sendable {
   case success(AppRoute)
+  case issuerNotTrusted
   case noPending
   case failure(Error)
 }

--- a/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentView.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentView.swift
@@ -46,6 +46,13 @@ struct AddDocumentView<Router: RouterHost>: View {
         )
       }
     }
+    .sheetDialog(isPresented: $viewModel.isIssuerNotTrustedSheetShowing) {
+      TrustBlockedSheetContent(
+        title: .issuanceBlockedTitle,
+        message: .issuanceBlockedMessage,
+        onClose: { viewModel.isIssuerNotTrustedSheetShowing = false }
+      )
+    }
     .task {
       await self.viewModel.initialize()
     }

--- a/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentViewModel.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Add/AddDocumentViewModel.swift
@@ -18,6 +18,7 @@ import logic_resources
 import feature_common
 import logic_core
 import OrderedCollections
+import Observation
 
 @Copyable
 struct AddDocumentViewState: ViewState {
@@ -37,7 +38,10 @@ struct AddDocumentViewState: ViewState {
   }
 }
 
+@Observable
 final class AddDocumentViewModel<Router: RouterHost>: ViewModel<Router, AddDocumentViewState> {
+
+  var isIssuerNotTrustedSheetShowing: Bool = false
 
   private let interactor: AddDocumentInteractor
   private let deepLinkController: DeepLinkController
@@ -204,6 +208,14 @@ final class AddDocumentViewModel<Router: RouterHost>: ViewModel<Router, AddDocum
           addDocumentCellModels: transformCellLoadingState(with: false)
         )
       }
+    case .issuerNotTrusted:
+      setState {
+        $0.copy(
+          addDocumentCellModels: transformCellLoadingState(with: false)
+        )
+        .copy(error: nil)
+      }
+      isIssuerNotTrustedSheetShowing = true
     case .failure(let error):
       setState {
         $0.copy(
@@ -253,6 +265,14 @@ final class AddDocumentViewModel<Router: RouterHost>: ViewModel<Router, AddDocum
             )
           )
         )
+      case .issuerNotTrusted:
+        setState {
+          $0.copy(
+            addDocumentCellModels: transformCellLoadingState(with: false)
+          )
+          .copy(error: nil)
+        }
+        isIssuerNotTrustedSheetShowing = true
       case .failure(let error):
         setState {
           $0.copy(

--- a/Modules/feature-issuance/Sources/UI/Document/Code/OfferCodeView.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Code/OfferCodeView.swift
@@ -37,6 +37,16 @@ struct OfferCodeView<Router: RouterHost>: View {
         codeIsFocused: $viewModel.codeIsFocused
       )
     }
+    .sheetDialog(isPresented: $viewModel.isIssuerNotTrustedSheetShowing) {
+      TrustBlockedSheetContent(
+        title: .issuanceBlockedTitle,
+        message: .issuanceBlockedMessage,
+        onClose: {
+          viewModel.isIssuerNotTrustedSheetShowing = false
+          viewModel.onPop()
+        }
+      )
+    }
     .task {
       await viewModel.checkPendingIssuance()
     }

--- a/Modules/feature-issuance/Sources/UI/Document/Code/OfferCodeViewModel.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Code/OfferCodeViewModel.swift
@@ -32,6 +32,8 @@ struct OfferCodeViewState: ViewState {
 @Observable
 final class OfferCodeViewModel<Router: RouterHost>: ViewModel<Router, OfferCodeViewState> {
 
+  var isIssuerNotTrustedSheetShowing: Bool = false
+
   var codeInput: String = "" {
     didSet {
       debouncedCodeInput.send(codeInput)
@@ -90,6 +92,9 @@ final class OfferCodeViewModel<Router: RouterHost>: ViewModel<Router, OfferCodeV
     case .success(let route):
       router.push(with: route)
     case .noPending: break
+    case .issuerNotTrusted:
+      setState { $0.copy(isLoading: false).copy(error: nil) }
+      isIssuerNotTrustedSheetShowing = true
     case .failure(let error):
       setState {
         $0.copy(
@@ -164,6 +169,9 @@ final class OfferCodeViewModel<Router: RouterHost>: ViewModel<Router, OfferCodeV
             )
           )
         )
+      case .issuerNotTrusted:
+        setState { $0.copy(isLoading: false).copy(error: nil) }
+        isIssuerNotTrustedSheetShowing = true
       case .failure(let error):
         setState {
           $0.copy(

--- a/Modules/feature-issuance/Sources/UI/Document/Offer/DocumentOfferView.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Offer/DocumentOfferView.swift
@@ -46,6 +46,13 @@ struct DocumentOfferView<Router: RouterHost>: View {
         onIssueDocuments: viewModel.onIssueDocuments
       )
     }
+    .sheetDialog(isPresented: $viewModel.isIssuerNotTrustedSheetShowing) {
+      TrustBlockedSheetContent(
+        title: .issuanceBlockedTitle,
+        message: .issuanceBlockedMessage,
+        onClose: { viewModel.isIssuerNotTrustedSheetShowing = false }
+      )
+    }
     .task {
       await viewModel.initialize()
     }

--- a/Modules/feature-issuance/Sources/UI/Document/Offer/DocumentOfferViewModel.swift
+++ b/Modules/feature-issuance/Sources/UI/Document/Offer/DocumentOfferViewModel.swift
@@ -17,6 +17,7 @@ import Foundation
 import logic_ui
 import logic_resources
 import feature_common
+import Observation
 
 @Copyable
 struct DocumentOfferViewState: ViewState {
@@ -42,7 +43,10 @@ struct DocumentOfferViewState: ViewState {
   }
 }
 
+@Observable
 final class DocumentOfferViewModel<Router: RouterHost>: ViewModel<Router, DocumentOfferViewState> {
+
+  var isIssuerNotTrustedSheetShowing: Bool = false
 
   private let interactor: DocumentOfferInteractor
 
@@ -179,6 +183,9 @@ final class DocumentOfferViewModel<Router: RouterHost>: ViewModel<Router, Docume
             )
           )
         )
+      case .issuerNotTrusted:
+        setState { $0.copy(isLoading: false).copy(error: nil) }
+        isIssuerNotTrustedSheetShowing = true
       case .failure(let error):
         setState {
           $0.copy(
@@ -249,6 +256,9 @@ final class DocumentOfferViewModel<Router: RouterHost>: ViewModel<Router, Docume
       router.push(with: route)
     case .noPending:
       setState { $0.copy(isLoading: false) }
+    case .issuerNotTrusted:
+      setState { $0.copy(isLoading: false).copy(error: nil) }
+      isIssuerNotTrustedSheetShowing = true
     case .failure(let error):
       setState {
         $0.copy(

--- a/Modules/feature-issuance/Tests/Interactor/TestAddDocumentInteractor.swift
+++ b/Modules/feature-issuance/Tests/Interactor/TestAddDocumentInteractor.swift
@@ -14,6 +14,7 @@
  * governing permissions and limitations under the Licence.
  */
 import XCTest
+import EudiWalletKit
 
 @testable import logic_core
 @testable import logic_test
@@ -197,6 +198,66 @@ final class TestAddDocumentInteractor: EudiTest {
     }
   }
   
+  func testIssueDocument_whenWalletThrowsTrustError_thenReturnsIssuerNotTrusted() async {
+    // Given
+    let configIds = ["untrusted-doc"]
+    let issuerId = "issuer.dev"
+    let identifier = DocumentTypeIdentifier(rawValue: "eu.europa.ec.eudi.pid.1")
+
+    stub(walletKitController) { mock in
+      when(
+        mock.issueDocuments(
+          issuerId: equal(to: issuerId),
+          identifiers: equal(to: configIds),
+          docTypeIdentifier: equal(to: identifier)
+        )
+      ).thenThrow(WalletError(description: "issuer not trusted", code: .trustError))
+    }
+
+    // When
+    let result = await interactor.issueDocument(
+      issuerId: issuerId,
+      configIds: configIds,
+      docTypeIdentifier: identifier
+    )
+
+    // Then
+    switch result {
+    case .issuerNotTrusted:
+      XCTAssertTrue(true)
+    default:
+      XCTFail("Expected .issuerNotTrusted but got \(result)")
+    }
+  }
+
+  func testResumeDynamicIssuance_whenWalletThrowsTrustError_thenReturnsIssuerNotTrusted() async {
+    // Given
+    let pendingData = DynamicIssuancePendingData(
+      pendingDoc: Constants.issuedPendingDocument,
+      url: URL(string: "https://example.com")!
+    )
+
+    stub(walletKitController) { mock in
+      when(mock.getDynamicIssuancePendingData()).thenReturn(pendingData)
+
+      when(mock.resumePendingIssuance(
+        pendingDoc: any(),
+        webUrl: equal(to: pendingData.url)
+      )).thenThrow(WalletError(description: "issuer not trusted", code: .trustError))
+    }
+
+    // When
+    let result = await interactor.resumeDynamicIssuance()
+
+    // Then
+    switch result {
+    case .issuerNotTrusted:
+      XCTAssertTrue(true)
+    default:
+      XCTFail("Expected .issuerNotTrusted but got \(result)")
+    }
+  }
+
   func testResumeDynamicIssuance_whenDefferedPending_thenReturnDefferedSuccess() async {
     // Given
     let pendingDoc = Constants.defferedPendingDocument

--- a/Modules/feature-issuance/Tests/Interactor/TestDocumentOfferInteractor.swift
+++ b/Modules/feature-issuance/Tests/Interactor/TestDocumentOfferInteractor.swift
@@ -21,6 +21,7 @@ import XCTest
 @testable import feature_common
 @testable import feature_issuance
 import OpenID4VCI
+import EudiWalletKit
 
 final class TestDocumentOfferInteractor: EudiTest {
   
@@ -325,6 +326,106 @@ final class TestDocumentOfferInteractor: EudiTest {
     }
   }
   
+  func testIssueDocuments_WhenWalletThrowsTrustError_ThenReturnsIssuerNotTrusted() async {
+    // Given
+    let config = UIConfig.TwoWayNavigationType.push(
+      .featureCommonModule(
+        .genericSuccess(config: UIConfig.Success(
+          title: .init(value: .addDocumentTitle),
+          subtitle: .addDocumentTitle,
+          buttons: [],
+          visualKind: UIConfig.Success.VisualKind.defaultIcon)
+        )
+      )
+    )
+
+    let uri = "uri"
+    let txCodeValue = "txCodeValue"
+
+    stub(walletKitController) { mock in
+      mock.issueDocumentsByOfferUrl(
+        offerUri: uri,
+        docTypes: any(),
+        txCodeValue: txCodeValue
+      )
+      .thenThrow(WalletError(description: "issuer not trusted", code: .trustError))
+    }
+
+    // When
+    let result = await interactor.issueDocuments(
+      with: uri,
+      issuerName: "issuerName",
+      docOffers: [],
+      successNavigation: config,
+      txCodeValue: txCodeValue
+    )
+
+    // Then
+    switch result {
+    case .issuerNotTrusted:
+      XCTAssertTrue(true)
+    default:
+      XCTFail("Expected .issuerNotTrusted but got \(result)")
+    }
+  }
+
+  func testResumeDynamicIssuance_WhenWalletThrowsTrustError_ThenReturnsIssuerNotTrusted() async {
+    // Given
+    let config = IssuanceCodeUiConfig(
+      offerUri: "",
+      issuerName: "Issuer Name",
+      txCodeLength: 6,
+      docOffers: [],
+      successNavigation: .popTo(
+        .featureIssuanceModule(
+          .credentialOfferRequest(config: NoConfig())
+        )
+      ),
+      navigationCancelType: .pop
+    )
+
+    let document = Document(
+      id: "doc-id",
+      docType: "type",
+      docDataFormat: .sdjwt,
+      data: Data(),
+      docKeyInfo: nil,
+      createdAt: Date(),
+      metadata: nil,
+      displayName: "My Document",
+      status: .issued
+    )
+
+    let mockPendingData = DynamicIssuancePendingData(
+      pendingDoc: document,
+      url: URL(filePath: "someURL")!
+    )
+
+    stub(walletKitController) { mock in
+      when(mock.getDynamicIssuancePendingData()).thenReturn(mockPendingData)
+
+      when(mock.resumePendingIssuance(
+        pendingDoc: any(),
+        webUrl: any()
+      ))
+      .thenThrow(WalletError(description: "issuer not trusted", code: .trustError))
+    }
+
+    // When
+    let result = await interactor.resumeDynamicIssuance(
+      issuerName: config.issuerName,
+      successNavigation: config.successNavigation
+    )
+
+    // Then
+    switch result {
+    case .issuerNotTrusted:
+      XCTAssertTrue(true)
+    default:
+      XCTFail("Expected .issuerNotTrusted but got \(result)")
+    }
+  }
+
   func testIssueDocuments_WhenIssueDocumentsByOfferUrl_ThenReturnFailure() async {
     // Given
     let config = UIConfig.TwoWayNavigationType.push(

--- a/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
@@ -6875,7 +6875,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -6921,12 +6921,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -7017,8 +7017,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -7069,8 +7069,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -7117,9 +7117,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
@@ -12011,7 +12011,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
 
 import Cuckoo
 import SwiftUI
@@ -12027,7 +12027,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
@@ -1811,6 +1811,7 @@ import logic_resources
 import Cuckoo
 import logic_resources
 import OrderedCollections
+import Observation
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -1905,6 +1906,7 @@ import logic_resources
 import Cuckoo
 import Foundation
 import logic_resources
+import Observation
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -9956,6 +9958,23 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_issuance
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo
@@ -11977,6 +11996,22 @@ import logic_resources
 
 
 // MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/SearchableList/SearchableListView.swift'
+
+import Cuckoo
+import SwiftUI
+import logic_resources
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_issuance
+
+
+
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-presentation/Sources/Interactor/PresentationInteractor.swift
+++ b/Modules/feature-presentation/Sources/Interactor/PresentationInteractor.swift
@@ -40,7 +40,7 @@ public enum RemoteSentResponsePartialState: Sendable {
 
 public enum PresentationRequestPartialState: Sendable {
   case success(OnlineAuthenticationRequestSuccessModel)
-  case verifierNotTrusted
+  case notSecuredRequest
   case failure(Error)
 }
 
@@ -121,7 +121,7 @@ final actor PresentationInteractorImpl: PresentationInteractor {
         )
       )
     } catch {
-      return error.isIssuerNotTrusted ? .verifierNotTrusted : .failure(error)
+      return error.isIssuerNotTrusted ? .notSecuredRequest : .failure(error)
     }
   }
 

--- a/Modules/feature-presentation/Sources/Interactor/PresentationInteractor.swift
+++ b/Modules/feature-presentation/Sources/Interactor/PresentationInteractor.swift
@@ -38,12 +38,18 @@ public enum RemoteSentResponsePartialState: Sendable {
   case failure(Error)
 }
 
+public enum PresentationRequestPartialState: Sendable {
+  case success(OnlineAuthenticationRequestSuccessModel)
+  case verifierNotTrusted
+  case failure(Error)
+}
+
 public protocol PresentationInteractor: Sendable {
   func getSessionStatePublisher() async -> RemotePublisherPartialState
   func getCoordinator() async -> PresentationCoordinatorPartialState
-  func onDeviceEngagement() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>
+  func onDeviceEngagement() async -> PresentationRequestPartialState
   func onResponsePrepare(requestItems: [RequestDataUiModel]) async -> Result<RequestItemConvertible, Error>
-  func onRequestReceived() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>
+  func onRequestReceived() async -> PresentationRequestPartialState
   func onSendResponse() async -> RemoteSentResponsePartialState
   func updatePresentationCoordinator(with coordinator: RemoteSessionCoordinator) async
   func storeDynamicIssuancePendingUrl(with url: URL) async
@@ -85,12 +91,12 @@ final actor PresentationInteractorImpl: PresentationInteractor {
     await self.sessionCoordinatorHolder.setActiveRemoteCoordinator(coordinator)
   }
 
-  public func onDeviceEngagement() async -> Result<OnlineAuthenticationRequestSuccessModel, Error> {
+  public func onDeviceEngagement() async -> PresentationRequestPartialState {
     try? await sessionCoordinatorHolder.getActiveRemoteCoordinator().initialize()
     return await onRequestReceived()
   }
 
-  public func onRequestReceived() async -> Result<OnlineAuthenticationRequestSuccessModel, Error> {
+  public func onRequestReceived() async -> PresentationRequestPartialState {
     do {
       let response = try await sessionCoordinatorHolder.getActiveRemoteCoordinator().requestReceived()
       let revokedDocuments = (try? await walletKitController.fetchRevokedDocuments()) ?? []
@@ -115,7 +121,7 @@ final actor PresentationInteractorImpl: PresentationInteractor {
         )
       )
     } catch {
-      return .failure(error)
+      return error.isIssuerNotTrusted ? .verifierNotTrusted : .failure(error)
     }
   }
 

--- a/Modules/feature-presentation/Sources/UI/Presentation/Request/PresentationRequestViewModel.swift
+++ b/Modules/feature-presentation/Sources/UI/Presentation/Request/PresentationRequestViewModel.swift
@@ -39,6 +39,10 @@ final class PresentationRequestViewModel<Router: RouterHost>: BaseRequestViewMod
 
     switch result {
     case .success(let authenticationRequest):
+      guard authenticationRequest.isTrusted else {
+        self.onVerifierNotTrusted()
+        return
+      }
       self.onReceivedCombinations(
         with: authenticationRequest.requestDataCombinations,
         title: .requestDataTitle(
@@ -120,6 +124,10 @@ final class PresentationRequestViewModel<Router: RouterHost>: BaseRequestViewMod
 
   override func getPopRoute() -> AppRoute? {
     return getOriginator()
+  }
+
+  override func stopPresentation() async {
+    await interactor.stopPresentation()
   }
 
   override func getTitle() -> LocalizableStringKey {

--- a/Modules/feature-presentation/Sources/UI/Presentation/Request/PresentationRequestViewModel.swift
+++ b/Modules/feature-presentation/Sources/UI/Presentation/Request/PresentationRequestViewModel.swift
@@ -63,7 +63,7 @@ final class PresentationRequestViewModel<Router: RouterHost>: BaseRequestViewMod
           )
         )
       }
-    case .verifierNotTrusted:
+    case .notSecuredRequest:
       self.onVerifierNotTrusted()
     case .failure(let error):
       self.onEmptyDocuments(error: error.errorMessage)

--- a/Modules/feature-presentation/Sources/UI/Presentation/Request/PresentationRequestViewModel.swift
+++ b/Modules/feature-presentation/Sources/UI/Presentation/Request/PresentationRequestViewModel.swift
@@ -39,10 +39,6 @@ final class PresentationRequestViewModel<Router: RouterHost>: BaseRequestViewMod
 
     switch result {
     case .success(let authenticationRequest):
-      guard authenticationRequest.isTrusted else {
-        self.onVerifierNotTrusted()
-        return
-      }
       self.onReceivedCombinations(
         with: authenticationRequest.requestDataCombinations,
         title: .requestDataTitle(
@@ -67,6 +63,8 @@ final class PresentationRequestViewModel<Router: RouterHost>: BaseRequestViewMod
           )
         )
       }
+    case .verifierNotTrusted:
+      self.onVerifierNotTrusted()
     case .failure(let error):
       self.onEmptyDocuments(error: error.errorMessage)
     }

--- a/Modules/feature-presentation/Tests/Interactor/TestPresentationInteractor.swift
+++ b/Modules/feature-presentation/Tests/Interactor/TestPresentationInteractor.swift
@@ -17,6 +17,7 @@ import XCTest
 import UIKit
 import logic_business
 import feature_common
+import EudiWalletKit
 @testable import logic_core
 @testable import feature_presentation
 @testable import logic_test
@@ -340,6 +341,27 @@ final class TestPresentationInteractor: EudiTest {
         error.localizedDescription,
         expectedError.localizedDescription
       )
+    default:
+      XCTFail("Wrong state \(state)")
+    }
+  }
+
+  func testOnRequestReceived_WhenCoordinatorRequestReceivedThrowsTrustError_ThenReturnsNotSecuredRequest() async {
+    // Given
+    stub(presentationCoordinator) { mock in
+      when(mock.requestReceived())
+        .thenThrow(WalletError(description: "verifier not trusted", code: .trustError))
+    }
+
+    stubFetchRevokedDocuments(with: [])
+
+    // When
+    let state = await interactor.onRequestReceived()
+
+    // Then
+    switch state {
+    case .notSecuredRequest:
+      XCTAssertTrue(true)
     default:
       XCTFail("Wrong state \(state)")
     }

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -11842,7 +11842,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
 
 import Cuckoo
 import SwiftUI
@@ -11858,7 +11858,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -6708,7 +6708,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -6754,12 +6754,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -6850,8 +6850,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -6902,8 +6902,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -6950,9 +6950,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -9789,6 +9789,23 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_presentation
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo
@@ -11810,6 +11827,22 @@ import logic_resources
 
 
 // MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/SearchableList/SearchableListView.swift'
+
+import Cuckoo
+import SwiftUI
+import logic_resources
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_presentation
+
+
+
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -1420,9 +1420,9 @@ public class MockPresentationInteractor: PresentationInteractor, Cuckoo.Protocol
         )
     }
 
-    public func onDeviceEngagement() async -> Result<OnlineAuthenticationRequestSuccessModel, Error> {
+    public func onDeviceEngagement() async -> PresentationRequestPartialState {
         return await cuckoo_manager.call(
-            "onDeviceEngagement() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>",
+            "onDeviceEngagement() async -> PresentationRequestPartialState",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -1440,9 +1440,9 @@ public class MockPresentationInteractor: PresentationInteractor, Cuckoo.Protocol
         )
     }
 
-    public func onRequestReceived() async -> Result<OnlineAuthenticationRequestSuccessModel, Error> {
+    public func onRequestReceived() async -> PresentationRequestPartialState {
         return await cuckoo_manager.call(
-            "onRequestReceived() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>",
+            "onRequestReceived() async -> PresentationRequestPartialState",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -1513,10 +1513,10 @@ public class MockPresentationInteractor: PresentationInteractor, Cuckoo.Protocol
             ))
         }
         
-        func onDeviceEngagement() -> Cuckoo.ProtocolStubFunction<(), Result<OnlineAuthenticationRequestSuccessModel, Error>> {
+        func onDeviceEngagement() -> Cuckoo.ProtocolStubFunction<(), PresentationRequestPartialState> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockPresentationInteractor.self,
-                method: "onDeviceEngagement() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>",
+                method: "onDeviceEngagement() async -> PresentationRequestPartialState",
                 parameterMatchers: matchers
             ))
         }
@@ -1529,10 +1529,10 @@ public class MockPresentationInteractor: PresentationInteractor, Cuckoo.Protocol
             ))
         }
         
-        func onRequestReceived() -> Cuckoo.ProtocolStubFunction<(), Result<OnlineAuthenticationRequestSuccessModel, Error>> {
+        func onRequestReceived() -> Cuckoo.ProtocolStubFunction<(), PresentationRequestPartialState> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockPresentationInteractor.self,
-                method: "onRequestReceived() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>",
+                method: "onRequestReceived() async -> PresentationRequestPartialState",
                 parameterMatchers: matchers
             ))
         }
@@ -1607,10 +1607,10 @@ public class MockPresentationInteractor: PresentationInteractor, Cuckoo.Protocol
         
         
         @discardableResult
-        func onDeviceEngagement() -> Cuckoo.__DoNotUse<(), Result<OnlineAuthenticationRequestSuccessModel, Error>> {
+        func onDeviceEngagement() -> Cuckoo.__DoNotUse<(), PresentationRequestPartialState> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "onDeviceEngagement() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>",
+                "onDeviceEngagement() async -> PresentationRequestPartialState",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -1631,10 +1631,10 @@ public class MockPresentationInteractor: PresentationInteractor, Cuckoo.Protocol
         
         
         @discardableResult
-        func onRequestReceived() -> Cuckoo.__DoNotUse<(), Result<OnlineAuthenticationRequestSuccessModel, Error>> {
+        func onRequestReceived() -> Cuckoo.__DoNotUse<(), PresentationRequestPartialState> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "onRequestReceived() async -> Result<OnlineAuthenticationRequestSuccessModel, Error>",
+                "onRequestReceived() async -> PresentationRequestPartialState",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -1703,16 +1703,16 @@ public class PresentationInteractorStub:PresentationInteractor, @unchecked Senda
         return DefaultValueRegistry.defaultValue(for: (PresentationCoordinatorPartialState).self)
     }
     
-    public func onDeviceEngagement() async -> Result<OnlineAuthenticationRequestSuccessModel, Error> {
-        return DefaultValueRegistry.defaultValue(for: (Result<OnlineAuthenticationRequestSuccessModel, Error>).self)
+    public func onDeviceEngagement() async -> PresentationRequestPartialState {
+        return DefaultValueRegistry.defaultValue(for: (PresentationRequestPartialState).self)
     }
     
     public func onResponsePrepare(requestItems p0: [RequestDataUiModel]) async -> Result<RequestItemConvertible, Error> {
         return DefaultValueRegistry.defaultValue(for: (Result<RequestItemConvertible, Error>).self)
     }
     
-    public func onRequestReceived() async -> Result<OnlineAuthenticationRequestSuccessModel, Error> {
-        return DefaultValueRegistry.defaultValue(for: (Result<OnlineAuthenticationRequestSuccessModel, Error>).self)
+    public func onRequestReceived() async -> PresentationRequestPartialState {
+        return DefaultValueRegistry.defaultValue(for: (PresentationRequestPartialState).self)
     }
     
     public func onSendResponse() async -> RemoteSentResponsePartialState {

--- a/Modules/feature-proximity/Sources/Interactor/ProximityInteractor.swift
+++ b/Modules/feature-proximity/Sources/Interactor/ProximityInteractor.swift
@@ -34,6 +34,7 @@ public enum ProximityResponsePreparationPartialState: Sendable {
 
 public enum ProximityRequestPartialState: Sendable {
   case success([RequestDataUiModel], relyingParty: String, dataRequestInfo: String, isTrusted: Bool)
+  case verifierNotTrusted
   case failure(Error)
 }
 
@@ -131,7 +132,7 @@ final actor ProximityInteractorImpl: ProximityInteractor {
         isTrusted: response.isTrusted
       )
     } catch {
-      return .failure(error)
+      return error.isIssuerNotTrusted ? .verifierNotTrusted : .failure(error)
     }
   }
 

--- a/Modules/feature-proximity/Sources/Interactor/ProximityInteractor.swift
+++ b/Modules/feature-proximity/Sources/Interactor/ProximityInteractor.swift
@@ -34,7 +34,7 @@ public enum ProximityResponsePreparationPartialState: Sendable {
 
 public enum ProximityRequestPartialState: Sendable {
   case success([RequestDataUiModel], relyingParty: String, dataRequestInfo: String, isTrusted: Bool)
-  case verifierNotTrusted
+  case notSecuredRequest
   case failure(Error)
 }
 
@@ -132,7 +132,7 @@ final actor ProximityInteractorImpl: ProximityInteractor {
         isTrusted: response.isTrusted
       )
     } catch {
-      return error.isIssuerNotTrusted ? .verifierNotTrusted : .failure(error)
+      return error.isIssuerNotTrusted ? .notSecuredRequest : .failure(error)
     }
   }
 

--- a/Modules/feature-proximity/Sources/UI/Presentation/Request/ProximityRequestViewModel.swift
+++ b/Modules/feature-proximity/Sources/UI/Presentation/Request/ProximityRequestViewModel.swift
@@ -42,6 +42,10 @@ final class ProximityRequestViewModel<Router: RouterHost>: BaseRequestViewModel<
 
     switch state {
     case .success(let items, let relyingParty, _, let isTrusted):
+      guard isTrusted else {
+        self.onVerifierNotTrusted()
+        return
+      }
       self.onReceivedItems(
         with: items,
         title: .requestDataTitle([relyingParty]),
@@ -121,6 +125,10 @@ final class ProximityRequestViewModel<Router: RouterHost>: BaseRequestViewModel<
   override func getPopRoute() -> AppRoute? {
     publisherTask?.cancel()
     return getOriginator()
+  }
+
+  override func stopPresentation() async {
+    await interactor.stopPresentation()
   }
 
   override func getTitle() -> LocalizableStringKey {

--- a/Modules/feature-proximity/Sources/UI/Presentation/Request/ProximityRequestViewModel.swift
+++ b/Modules/feature-proximity/Sources/UI/Presentation/Request/ProximityRequestViewModel.swift
@@ -64,7 +64,7 @@ final class ProximityRequestViewModel<Router: RouterHost>: BaseRequestViewModel<
           )
         )
       }
-    case .verifierNotTrusted:
+    case .notSecuredRequest:
       self.onVerifierNotTrusted()
     case .failure(let error):
       self.onEmptyDocuments(error: error.errorMessage)

--- a/Modules/feature-proximity/Sources/UI/Presentation/Request/ProximityRequestViewModel.swift
+++ b/Modules/feature-proximity/Sources/UI/Presentation/Request/ProximityRequestViewModel.swift
@@ -42,10 +42,6 @@ final class ProximityRequestViewModel<Router: RouterHost>: BaseRequestViewModel<
 
     switch state {
     case .success(let items, let relyingParty, _, let isTrusted):
-      guard isTrusted else {
-        self.onVerifierNotTrusted()
-        return
-      }
       self.onReceivedItems(
         with: items,
         title: .requestDataTitle([relyingParty]),
@@ -68,6 +64,8 @@ final class ProximityRequestViewModel<Router: RouterHost>: BaseRequestViewModel<
           )
         )
       }
+    case .verifierNotTrusted:
+      self.onVerifierNotTrusted()
     case .failure(let error):
       self.onEmptyDocuments(error: error.errorMessage)
     }

--- a/Modules/feature-proximity/Tests/Interactor/TestProximityInteractor.swift
+++ b/Modules/feature-proximity/Tests/Interactor/TestProximityInteractor.swift
@@ -18,6 +18,7 @@ import UIKit
 import logic_resources
 import logic_business
 import feature_common
+import EudiWalletKit
 @testable import logic_core
 @testable import feature_proximity
 @testable import logic_test
@@ -302,16 +303,16 @@ final class TestProximityInteractor: EudiTest {
   func testOnRequestReceived_WhenCoordinatorRequestReceivedThrowsError_ThenVerifyFailureState() async {
     // Given
     let expectedError = PresentationSessionError.conversionToRequestItemModel
-    
+
     stub(presentationSessionCoordinator) { mock in
       when(mock.requestReceived()).thenThrow(expectedError)
     }
-    
+
     stubFetchRevokedDocuments(with: [])
-    
+
     // When
     let state = await interactor.onRequestReceived()
-    
+
     // Then
     switch state {
     case .failure(let error):
@@ -319,6 +320,27 @@ final class TestProximityInteractor: EudiTest {
         error.localizedDescription,
         expectedError.localizedDescription
       )
+    default:
+      XCTFail("Wrong state \(state)")
+    }
+  }
+
+  func testOnRequestReceived_WhenCoordinatorRequestReceivedThrowsTrustError_ThenVerifyNotSecuredRequest() async {
+    // Given
+    stub(presentationSessionCoordinator) { mock in
+      when(mock.requestReceived())
+        .thenThrow(WalletError(description: "reader not trusted", code: .trustError))
+    }
+
+    stubFetchRevokedDocuments(with: [])
+
+    // When
+    let state = await interactor.onRequestReceived()
+
+    // Then
+    switch state {
+    case .notSecuredRequest:
+      XCTAssertTrue(true)
     default:
       XCTFail("Wrong state \(state)")
     }

--- a/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
@@ -9786,6 +9786,23 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_proximity
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo
@@ -11807,6 +11824,22 @@ import logic_resources
 
 
 // MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/SearchableList/SearchableListView.swift'
+
+import Cuckoo
+import SwiftUI
+import logic_resources
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_proximity
+
+
+
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
@@ -6705,7 +6705,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -6751,12 +6751,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -6847,8 +6847,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -6899,8 +6899,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -6947,9 +6947,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
@@ -11839,7 +11839,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
 
 import Cuckoo
 import SwiftUI
@@ -11855,7 +11855,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
@@ -6423,7 +6423,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -6469,12 +6469,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -6565,8 +6565,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -6617,8 +6617,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -6665,9 +6665,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
@@ -9504,6 +9504,23 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_startup
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo
@@ -11525,6 +11542,22 @@ import logic_resources
 
 
 // MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/SearchableList/SearchableListView.swift'
+
+import Cuckoo
+import SwiftUI
+import logic_resources
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+@testable import logic_api
+@testable import logic_authentication
+@testable import feature_common
+@testable import feature_startup
+
+
+
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
@@ -11557,7 +11557,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
 
 import Cuckoo
 import SwiftUI
@@ -11573,7 +11573,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
@@ -7096,6 +7096,19 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_authentication
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo

--- a/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
@@ -4074,7 +4074,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -4116,12 +4116,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -4212,8 +4212,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -4264,8 +4264,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -4312,9 +4312,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.36.0"
+      exact: "0.36.1"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.37.1"
+      exact: "0.37.2"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.35.2"
+      exact: "0.36.0"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.34.4"
+      exact: "0.35.1"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.36.1"
+      exact: "0.36.2"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.35.1"
+      exact: "0.35.2"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.36.2"
+      exact: "0.37.1"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.37.2"
+      exact: "0.37.3"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -235,9 +235,9 @@ struct WalletKitConfigImpl: WalletKitConfig {
       fallbackTrustSource: .staticList(
         StaticListTrustSource(rootCertificates: staticRootCertificates)
       ),
-      defaultPolicy: .enforce,
+      defaultPolicy: .warning,
       requireSignedMetadata: true,
-      statusTrustPolicy: .enforce
+      statusTrustPolicy: .warning
     )
   }
 

--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -109,11 +109,18 @@ struct WalletKitConfigImpl: WalletKitConfig {
           .init(
             config: .init(
               credentialIssuerURL: "https://issuer.eudiw.dev",
-              clientId: "wallet-dev",
-              keyAttestationsConfig: .init(walletAttestationsProvider: walletKitAttestationProvider),
+              clientId: "eudiw-abca",
+              keyAttestationsConfig: .init(
+                walletAttestationsProvider: walletKitAttestationProvider,
+                popKeyOptions: KeyOptions(
+                  secureAreaName: SecureEnclaveSecureArea.name,
+                  accessControl: []
+                )
+              ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
               parUsage: .required(authorizationCodeDPoPBinding: true),
               requireDpop: true,
+              issuerMetadataPolicy: trustConfiguration.issuerMetadataPolicy,
               cacheIssuerMetadata: true
             ),
             order: 1
@@ -121,11 +128,18 @@ struct WalletKitConfigImpl: WalletKitConfig {
           .init(
             config: .init(
               credentialIssuerURL: "https://issuer-backend.eudiw.dev",
-              clientId: "wallet-dev",
-              keyAttestationsConfig: .init(walletAttestationsProvider: walletKitAttestationProvider),
+              clientId: "eudiw-abca",
+              keyAttestationsConfig: .init(
+                walletAttestationsProvider: walletKitAttestationProvider,
+                popKeyOptions: KeyOptions(
+                  secureAreaName: SecureEnclaveSecureArea.name,
+                  accessControl: []
+                )
+              ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
               parUsage: .required(authorizationCodeDPoPBinding: true),
               requireDpop: true,
+              issuerMetadataPolicy: trustConfiguration.issuerMetadataPolicy,
               cacheIssuerMetadata: true
             ),
             order: 0
@@ -136,11 +150,18 @@ struct WalletKitConfigImpl: WalletKitConfig {
           .init(
             config: .init(
               credentialIssuerURL: "https://ec.dev.issuer.eudiw.dev",
-              clientId: "wallet-dev",
-              keyAttestationsConfig: .init(walletAttestationsProvider: walletKitAttestationProvider),
+              clientId: "eudiw-abca",
+              keyAttestationsConfig: .init(
+                walletAttestationsProvider: walletKitAttestationProvider,
+                popKeyOptions: KeyOptions(
+                  secureAreaName: SecureEnclaveSecureArea.name,
+                  accessControl: []
+                )
+              ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
               parUsage: .required(authorizationCodeDPoPBinding: true),
               requireDpop: true,
+              issuerMetadataPolicy: trustConfiguration.issuerMetadataPolicy,
               cacheIssuerMetadata: true
             ),
             order: 1
@@ -148,11 +169,18 @@ struct WalletKitConfigImpl: WalletKitConfig {
           .init(
             config: .init(
               credentialIssuerURL: "https://dev.issuer-backend.eudiw.dev",
-              clientId: "wallet-dev",
-              keyAttestationsConfig: .init(walletAttestationsProvider: walletKitAttestationProvider),
+              clientId: "eudiw-abca",
+              keyAttestationsConfig: .init(
+                walletAttestationsProvider: walletKitAttestationProvider,
+                popKeyOptions: KeyOptions(
+                  secureAreaName: SecureEnclaveSecureArea.name,
+                  accessControl: []
+                )
+              ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
               parUsage: .required(authorizationCodeDPoPBinding: true),
               requireDpop: true,
+              issuerMetadataPolicy: trustConfiguration.issuerMetadataPolicy,
               cacheIssuerMetadata: true
             ),
             order: 0
@@ -204,10 +232,26 @@ struct WalletKitConfigImpl: WalletKitConfig {
           contextTypeMappings: classifications
         )
       ),
-      defaultPolicy: .warning,
+      fallbackTrustSource: .staticList(
+        StaticListTrustSource(rootCertificates: staticRootCertificates)
+      ),
+      defaultPolicy: .enforce,
       requireSignedMetadata: true,
-      statusTrustPolicy: .warning
+      statusTrustPolicy: .enforce
     )
+  }
+
+  var staticRootCertificates: [Data] {
+    [
+      "pidissuerca02_cz",
+      "pidissuerca02_ee",
+      "pidissuerca02_eu",
+      "pidissuerca02_lu",
+      "pidissuerca02_nl",
+      "pidissuerca02_pt",
+      "pidissuerca02_ut",
+      "r45_staging"
+    ].compactMap { loadCertificate($0) }
   }
 
   var logFileName: String {
@@ -310,5 +354,14 @@ struct WalletKitConfigImpl: WalletKitConfig {
         )
       )
     }
+  }
+}
+
+private extension WalletKitConfigImpl {
+  func loadCertificate(_ name: String) -> Data? {
+    guard let url = Bundle.main.url(forResource: name, withExtension: "der") else {
+      return nil
+    }
+    return try? Data(contentsOf: url)
   }
 }

--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -16,7 +16,7 @@
 import Foundation
 import logic_business
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 
 protocol WalletKitConfig: Sendable {
 
@@ -31,9 +31,10 @@ protocol WalletKitConfig: Sendable {
   var vpConfig: OpenId4VpConfiguration { get }
 
   /**
-   * Reader Configuration
+   * Trust configuration: ETSI LoTE (List of Trusted Entities) trust sources,
+   * verification-context mappings and trust policies used for reader / issuer validation.
    */
-  var trustedReaderRootCertificates: [x5chain] { get }
+  var trustConfiguration: TrustConfiguration { get }
 
   /**
    * User authentication required accessing core's secure storage
@@ -180,20 +181,31 @@ struct WalletKitConfigImpl: WalletKitConfig {
     )
   }
 
-  var trustedReaderRootCertificates: [x5chain] {
-    let certificates = [
-      "pidissuerca02_cz",
-      "pidissuerca02_ee",
-      "pidissuerca02_eu",
-      "pidissuerca02_lu",
-      "pidissuerca02_nl",
-      "pidissuerca02_pt",
-      "pidissuerca02_ut",
-      "r45_staging"
+  var trustConfiguration: TrustConfiguration {
+    let loteLocations = SupportedLists<NSString>(
+      pidProviders: "https://trustedlist.serviceproviders.eudiw.dev/LOTE/json/PIDProviders.jwt",
+      walletProviders: nil,
+      wrpacProviders: "https://trustedlist.serviceproviders.eudiw.dev/LOTE/json/WRPACProviders.jwt",
+      wrprcProviders: nil,
+      pubEaaProviders: "https://trustedlist.serviceproviders.eudiw.dev/LOTE/json/PubEAAProviders.jwt",
+      qeaProviders: nil,
+      eaaProviders: [:]
+    )
+
+    let classifications: EtsiContextTypeMappings = [
+      DocumentTypeIdentifier.mDocPid.rawValue: .pid,
+      DocumentTypeIdentifier.sdJwtPid.rawValue: .pid
     ]
-    return certificates
-      .compactMap { loadCertificate($0) }
-      .map { [$0] }
+
+    return TrustConfiguration(
+      trustSource: .etsi(
+        EtsiTrustSource(
+          loteLocations: loteLocations,
+          contextTypeMappings: classifications
+        )
+      ),
+      defaultPolicy: .warning
+    )
   }
 
   var logFileName: String {
@@ -296,15 +308,5 @@ struct WalletKitConfigImpl: WalletKitConfig {
         )
       )
     }
-  }
-}
-
-private extension WalletKitConfigImpl {
-  func loadCertificate(_ name: String) -> SecCertificate? {
-    guard
-      let url = Bundle.main.url(forResource: name, withExtension: "der"),
-      let data = try? Data(contentsOf: url)
-    else { return nil }
-    return SecCertificateCreateWithData(nil, data as CFData)
   }
 }

--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -204,7 +204,9 @@ struct WalletKitConfigImpl: WalletKitConfig {
           contextTypeMappings: classifications
         )
       ),
-      defaultPolicy: .warning
+      defaultPolicy: .warning,
+      requireSignedMetadata: true,
+      statusTrustPolicy: .warning
     )
   }
 

--- a/Modules/logic-core/Sources/Controller/WalletKitController.swift
+++ b/Modules/logic-core/Sources/Controller/WalletKitController.swift
@@ -138,11 +138,11 @@ final actor WalletKitControllerImpl: WalletKitController {
         serviceName: configLogic.keyChainConfig.documentStorageServiceName,
         accessGroup: configLogic.keyChainConfig.keychainAccessGroup,
         userAuthenticationRequired: walletKitConfig.userAuthenticationRequired,
-        trustedReaderRootCertificates: walletKitConfig.trustedReaderRootCertificates,
         deviceAuthMethod: .deviceSignature,
         uiCulture: Locale.current.systemLanguageCode,
         logFileName: walletKitConfig.logFileName
       ),
+      trustConfig: walletKitConfig.trustConfiguration,
       openID4VpConfig: walletKitConfig.vpConfig,
       openID4VciConfigurations: walletKitConfig.issuersConfig.mapValues { $0.config },
       networking: networkSessionProvider.urlSession,

--- a/Modules/logic-core/Sources/Coordinator/ProximitySessionCoordinator.swift
+++ b/Modules/logic-core/Sources/Coordinator/ProximitySessionCoordinator.swift
@@ -82,7 +82,7 @@ final class ProximitySessionCoordinatorImpl: ProximitySessionCoordinator {
       let qrImage = DeviceEngagement.getQrCodeImage(qrCode: deviceEngagement),
       let qrImageData = qrImage.pngData()
     else {
-      throw session.uiError ?? .init(description: "Failed To Generate QR Code")
+      throw session.uiError ?? .init(description: "Failed To Generate QR Code", code: .internalError)
     }
     self.sendableCurrentValueSubject.setValue(.qrReady(imageData: qrImageData))
     return qrImage
@@ -90,7 +90,7 @@ final class ProximitySessionCoordinatorImpl: ProximitySessionCoordinator {
 
   public func requestReceived() async throws -> PresentationRequest {
     guard session.disclosedDocumentSets.contains(where: { !$0.isEmpty }) else {
-      throw session.uiError ?? .init(description: "Failed to Find knonw documents to send")
+      throw session.uiError ?? .init(description: "Failed to Find knonw documents to send", code: .noDocumentsAvailable)
     }
     return createRequest()
   }

--- a/Modules/logic-core/Sources/Coordinator/RemoteSessionCoordinator.swift
+++ b/Modules/logic-core/Sources/Coordinator/RemoteSessionCoordinator.swift
@@ -71,7 +71,7 @@ final class RemoteSessionCoordinatorImpl: RemoteSessionCoordinator {
 
   public func requestReceived() async throws -> PresentationRequest {
     guard session.disclosedDocumentSets.contains(where: { !$0.isEmpty }) else {
-      throw session.uiError ?? .init(description: "Failed to Find known documents to send")
+      throw session.uiError ?? .init(description: "Failed to Find known documents to send", code: .noDocumentsAvailable)
     }
     return createRequest()
   }

--- a/Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift
+++ b/Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+
+public extension Error {
+  var isIssuerNotTrusted: Bool {
+    if let walletError = self as? WalletError, walletError.code == .trustError {
+      return true
+    }
+    if let msoError = self as? MsoValidationError, msoError.containsIssuerTrustFailure {
+      return true
+    }
+    return false
+  }
+}
+
+private extension MsoValidationError {
+  var containsIssuerTrustFailure: Bool {
+    switch self {
+    case .issuerTrustFailed:
+      return true
+    case .multipleErrors(let errors):
+      return errors.contains { $0.containsIssuerTrustFailure }
+    default:
+      return false
+    }
+  }
+}

--- a/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
+++ b/Modules/logic-resources/Sources/Localizable/LocalizableStringKey.swift
@@ -237,6 +237,10 @@ public enum LocalizableStringKey: Equatable, Sendable {
   case revoked
   case revokedModalTitle
   case revokedModalDescription
+  case issuanceBlockedTitle
+  case issuanceBlockedMessage
+  case presentationBlockedTitle
+  case presentationBlockedMessage
   case transactionDetailsRequestDeletionMessage
   case transactionDetailsRequestDeletionButton
   case transactionDetailsReportTransactionMessage

--- a/Modules/logic-resources/Sources/Manager/ImageManager.swift
+++ b/Modules/logic-resources/Sources/Manager/ImageManager.swift
@@ -29,6 +29,7 @@ public protocol ImageManagerProtocol: Sendable {
   var chevronLeft: Image { get }
   var xmark: Image { get }
   var exclamationmarkCircle: Image { get }
+  var exclamationmarkTriangleFill: Image { get }
   var circle: Image { get }
   var radioButtonSelected: Image { get }
   var radioButtonUnselected: Image { get }
@@ -94,6 +95,7 @@ final class ImageManager: ImageManagerProtocol {
     case chevronLeft = "chevron.left"
     case xmark = "xmark"
     case exclamationmarkCircle = "exclamationmark.circle"
+    case exclamationmarkTriangleFill = "exclamationmark.triangle.fill"
     case circle = "circle.fill"
     case radioButtonSelected = "largecircle.fill.circle"
     case radioButtonUnselected = "circle"
@@ -190,6 +192,9 @@ final class ImageManager: ImageManagerProtocol {
   }
   var exclamationmarkCircle: Image {
     Image(systemName: ImageEnum.exclamationmarkCircle.rawValue)
+  }
+  var exclamationmarkTriangleFill: Image {
+    Image(systemName: ImageEnum.exclamationmarkTriangleFill.rawValue)
   }
   var circle: Image {
     Image(systemName: ImageEnum.circle.rawValue)

--- a/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
+++ b/Modules/logic-resources/Sources/Manager/LocalizableManager.swift
@@ -470,6 +470,14 @@ final class LocalizableManager: LocalizableManagerType {
       bundle.localizedString(forKey: "revoked_modal_title")
     case .revokedModalDescription:
       bundle.localizedString(forKey: "revoked_modal_description")
+    case .issuanceBlockedTitle:
+      bundle.localizedString(forKey: "issuance_blocked_bottom_sheet_title")
+    case .issuanceBlockedMessage:
+      bundle.localizedString(forKey: "issuance_blocked_bottom_sheet_message")
+    case .presentationBlockedTitle:
+      bundle.localizedString(forKey: "request_blocked_bottom_sheet_title")
+    case .presentationBlockedMessage:
+      bundle.localizedString(forKey: "request_blocked_bottom_sheet_message")
     case .transactionDetailsRequestDeletionMessage:
       bundle.localizedString(forKey: "transaction_details_eequest_deletion_message")
     case .transactionDetailsRequestDeletionButton:

--- a/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
+++ b/Modules/logic-resources/Sources/Resources/Localizable.xcstrings
@@ -1126,6 +1126,50 @@
         }
       }
     },
+    "issuance_blocked_bottom_sheet_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Issuance blocked"
+          }
+        }
+      }
+    },
+    "issuance_blocked_bottom_sheet_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This issuance request has been blocked because the provider could not be verified by your Wallet.\n\nYour personal information or other data has not been shared with this provider."
+          }
+        }
+      }
+    },
+    "request_blocked_bottom_sheet_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presentation blocked"
+          }
+        }
+      }
+    },
+    "request_blocked_bottom_sheet_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This presentation request has been blocked because the relying party could not be verified by your Wallet.\n\nYour personal information or other data has not been shared with this relying party."
+          }
+        }
+      }
+    },
     "issuance_add_document_no_options" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift
+++ b/Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+import SwiftUI
+import logic_resources
+
+public struct TrustBlockedSheetContent: View {
+
+  private let title: LocalizableStringKey
+  private let message: LocalizableStringKey
+  private let onClose: () -> Void
+
+  public init(
+    title: LocalizableStringKey,
+    message: LocalizableStringKey,
+    onClose: @escaping () -> Void
+  ) {
+    self.title = title
+    self.message = message
+    self.onClose = onClose
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: SPACING_MEDIUM) {
+
+      HStack(spacing: SPACING_SMALL) {
+        Theme.shared.image.exclamationmarkTriangleFill
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 28, height: 28)
+          .foregroundStyle(Theme.shared.color.warning)
+
+        Text(title)
+          .typography(Theme.shared.font.titleLarge)
+          .fontWeight(.semibold)
+          .foregroundColor(Theme.shared.color.primaryLabel)
+
+        Spacer(minLength: SPACING_NONE)
+      }
+
+      Text(message)
+        .typography(Theme.shared.font.bodyLarge)
+        .foregroundColor(Theme.shared.color.primaryLabel)
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+      WrapButtonView(
+        style: .primary,
+        title: .close,
+        onAction: onClose()
+      )
+    }
+    .padding(.vertical)
+  }
+}
+
+#Preview {
+  TrustBlockedSheetContent(
+    title: .issuanceBlockedTitle,
+    message: .issuanceBlockedMessage,
+    onClose: {}
+  )
+}

--- a/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
@@ -6174,6 +6174,19 @@ import Cuckoo
 
 
 
+// MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/Error+IssuerTrust.swift'
+
+import Cuckoo
+import Foundation
+import EudiWalletKit
+import MdocSecurity18013
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+
+
+
 // MARK: - Mocks generated from file: '../Modules/logic-core/Sources/Extension/OfferedDocModel+Extensions.swift'
 
 import Cuckoo
@@ -7944,6 +7957,18 @@ import logic_resources
 
 
 // MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/SearchableList/SearchableListView.swift'
+
+import Cuckoo
+import SwiftUI
+import logic_resources
+@testable import logic_core
+@testable import logic_business
+@testable import logic_analytics
+@testable import logic_ui
+
+
+
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
@@ -3152,7 +3152,7 @@ import EudiWalletKit
 import Cuckoo
 import Foundation
 import EudiWalletKit
-import Security
+import EudiEtsi1196x2
 @testable import logic_core
 @testable import logic_business
 @testable import logic_analytics
@@ -3194,12 +3194,12 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
         }
     }
 
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
             return cuckoo_manager.getter(
-                "trustedReaderRootCertificates",
+                "trustConfiguration",
                 superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-                defaultCall: __defaultImplStub!.trustedReaderRootCertificates
+                defaultCall: __defaultImplStub!.trustConfiguration
             )
         }
     }
@@ -3290,8 +3290,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig")
         }
         
-        var trustedReaderRootCertificates: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates")
+        var trustConfiguration: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration")
         }
         
         var userAuthenticationRequired: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWalletKitConfig,Bool> {
@@ -3342,8 +3342,8 @@ class MockWalletKitConfig: WalletKitConfig, Cuckoo.ProtocolMock, @unchecked Send
             return .init(manager: cuckoo_manager, name: "vpConfig", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var trustedReaderRootCertificates: Cuckoo.VerifyReadOnlyProperty<[x5chain]> {
-            return .init(manager: cuckoo_manager, name: "trustedReaderRootCertificates", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var trustConfiguration: Cuckoo.VerifyReadOnlyProperty<TrustConfiguration> {
+            return .init(manager: cuckoo_manager, name: "trustConfiguration", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         var userAuthenticationRequired: Cuckoo.VerifyReadOnlyProperty<Bool> {
@@ -3390,9 +3390,9 @@ class WalletKitConfigStub:WalletKitConfig, @unchecked Sendable {
         }
     }
     
-    var trustedReaderRootCertificates: [x5chain] {
+    var trustConfiguration: TrustConfiguration {
         get {
-            return DefaultValueRegistry.defaultValue(for: ([x5chain]).self)
+            return DefaultValueRegistry.defaultValue(for: (TrustConfiguration).self)
         }
     }
     

--- a/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
@@ -7968,7 +7968,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/IssuerNotTrustedSheetContent.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
 
 import Cuckoo
 import SwiftUI
@@ -7980,7 +7980,7 @@ import logic_resources
 
 
 
-// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/SheetContainerView.swift'
+// MARK: - Mocks generated from file: '../Modules/logic-ui/Sources/DesignSystem/Component/Sheet/TrustBlockedSheetContent.swift'
 
 import Cuckoo
 import SwiftUI

--- a/wiki/CONFIGURATION.md
+++ b/wiki/CONFIGURATION.md
@@ -122,26 +122,59 @@ final class WalletProviderAttestationConfigImpl: WalletProviderAttestationConfig
 }
 ```
 
-3. Trusted certificates
+3. Trust configuration
 
 Via the *WalletKitConfig* protocol inside the logic-core module.
 
 ```swift
 protocol WalletKitConfig: Sendable {
   /**
-   * Reader Configuration
+   * Trust configuration: ETSI LoTE (List of Trusted Entities) trust sources,
+   * verification-context mappings and trust policies used for reader / issuer validation.
    */
-  var trustedReaderRootCertificates: [x5chain] { get }
+  var trustConfiguration: TrustConfiguration { get }
 }
 ```
 
-The *WalletKitConfigImpl* implementation of the *WalletKitConfig* protocol can be located inside the logic-core module.
+The *WalletKitConfigImpl* implementation of the *WalletKitConfig* protocol can be located inside the logic-core module. The resulting `TrustConfiguration` is passed to `EudiWallet` as the `trustConfig` argument in `WalletKitController`.
 
-The reader/IACA trust-anchor certificates ship with this repo as DER files in [`Wallet/Certificate`](../Wallet/Certificate) (e.g. `pidissuerca02_eu.der`, `r45_staging.der`). The file names — without the `.der` extension — must match the `certificates` array in `WalletKitConfigImpl.trustedReaderRootCertificates`, which loads each via `loadCertificate(_:)`. Replace these with your production trust anchors before go-live.
+The primary trust source is an ETSI LoTE (List of Trusted Entities) source that fetches signed trusted lists (PID / WRPAC / PubEAA providers) at runtime. A static list of bundled root certificates is configured as the `fallbackTrustSource`. These fallback certificates ship with this repo as DER files in [`Wallet/Certificate`](../Wallet/Certificate) (e.g. `pidissuerca02_eu.der`, `r45_staging.der`). The file names — without the `.der` extension — must match the array in `WalletKitConfigImpl.staticRootCertificates`, which loads each via `loadCertificate(_:)`. Replace the LoTE endpoints and the fallback anchors with your production values before go-live.
 
 ```swift
-  var trustedReaderRootCertificates: [x5chain] {
-    let certificates = [
+  var trustConfiguration: TrustConfiguration {
+    let loteLocations = SupportedLists<NSString>(
+      pidProviders: "https://trustedlist.serviceproviders.eudiw.dev/LOTE/json/PIDProviders.jwt",
+      walletProviders: nil,
+      wrpacProviders: "https://trustedlist.serviceproviders.eudiw.dev/LOTE/json/WRPACProviders.jwt",
+      wrprcProviders: nil,
+      pubEaaProviders: "https://trustedlist.serviceproviders.eudiw.dev/LOTE/json/PubEAAProviders.jwt",
+      qeaProviders: nil,
+      eaaProviders: [:]
+    )
+
+    let classifications: EtsiContextTypeMappings = [
+      DocumentTypeIdentifier.mDocPid.rawValue: .pid,
+      DocumentTypeIdentifier.sdJwtPid.rawValue: .pid
+    ]
+
+    return TrustConfiguration(
+      trustSource: .etsi(
+        EtsiTrustSource(
+          loteLocations: loteLocations,
+          contextTypeMappings: classifications
+        )
+      ),
+      fallbackTrustSource: .staticList(
+        StaticListTrustSource(rootCertificates: staticRootCertificates)
+      ),
+      defaultPolicy: .warning,
+      requireSignedMetadata: true,
+      statusTrustPolicy: .warning
+    )
+  }
+
+  var staticRootCertificates: [Data] {
+    [
       "pidissuerca02_cz",
       "pidissuerca02_ee",
       "pidissuerca02_eu",
@@ -150,10 +183,7 @@ The reader/IACA trust-anchor certificates ship with this repo as DER files in [`
       "pidissuerca02_pt",
       "pidissuerca02_ut",
       "r45_staging"
-    ]
-    return certificates
-      .compactMap { loadCertificate($0) }
-      .map { [$0] }
+    ].compactMap { loadCertificate($0) }
   }
 ```
 

--- a/wiki/GO_LIVE.md
+++ b/wiki/GO_LIVE.md
@@ -33,7 +33,7 @@ certification or a replacement for a full security assessment.
 * [`EudiWalletConfiguration`](#eudiwalletconfiguration)
 * [OpenID4VP Configuration](#openid4vp-configuration)
 * [Digital Credentials API And Identity Document Provider](#digital-credentials-api-and-identity-document-provider)
-* [Reader Trust Store](#reader-trust-store)
+* [Trust Store](#trust-store)
 * [Issuer Configuration: `issuersConfig`](#issuer-configuration-issuersconfig)
 * [Wallet Provider Attestation](#wallet-provider-attestation)
 * [Document Issuance Rules](#document-issuance-rules)
@@ -548,7 +548,7 @@ It implements:
 protocol WalletKitConfig: Sendable {
   var issuersConfig: [String: VciConfig] { get }
   var vpConfig: OpenId4VpConfiguration { get }
-  var trustedReaderRootCertificates: [x5chain] { get }
+  var trustConfiguration: TrustConfiguration { get }
   var userAuthenticationRequired: Bool { get }
   var keyOptions: KeyOptions? { get }
   var logFileName: String { get }
@@ -566,14 +566,19 @@ Each property must be reviewed.
 `WalletKitController` creates the wallet with:
 
 ```swift
-EudiWalletConfiguration(
-  serviceName: configLogic.keyChainConfig.documentStorageServiceName,
-  accessGroup: configLogic.keyChainConfig.keychainAccessGroup,
-  userAuthenticationRequired: walletKitConfig.userAuthenticationRequired,
-  trustedReaderRootCertificates: walletKitConfig.trustedReaderRootCertificates,
-  deviceAuthMethod: .deviceSignature,
-  uiCulture: Locale.current.systemLanguageCode,
-  logFileName: walletKitConfig.logFileName
+EudiWallet(
+  eudiWalletConfig: EudiWalletConfiguration(
+    serviceName: configLogic.keyChainConfig.documentStorageServiceName,
+    accessGroup: configLogic.keyChainConfig.keychainAccessGroup,
+    userAuthenticationRequired: walletKitConfig.userAuthenticationRequired,
+    deviceAuthMethod: .deviceSignature,
+    uiCulture: Locale.current.systemLanguageCode,
+    logFileName: walletKitConfig.logFileName
+  ),
+  trustConfig: walletKitConfig.trustConfiguration,
+  openID4VpConfig: walletKitConfig.vpConfig,
+  openID4VciConfigurations: walletKitConfig.issuersConfig.mapValues { $0.config },
+  // ...
 )
 ```
 
@@ -584,7 +589,7 @@ Production meaning:
 | `serviceName` | Keychain service name used by WalletKit storage. | Must be stable across app updates and match extension access needs. |
 | `accessGroup` | Keychain access group. | Must match signed entitlements and extension sharing requirements. |
 | `userAuthenticationRequired` | Whether WalletKit secure storage requires local user authentication. | For LoA High PID and other high-assurance EAA/QEAA credentials, set this to `true` unless an approved remote high-assurance hardware-backed key protection design replaces local key use. Test all issuance, presentation, extension, and background behavior. |
-| `trustedReaderRootCertificates` | Trust anchors for proximity reader authentication and supported verification flows. | Replace demo anchors with production trust anchors only. |
+| `trustConfig` | Trust configuration (`TrustConfiguration`) for reader / issuer validation: ETSI LoTE trust sources, verification-context mappings, static fallback anchors, and trust policies. Passed as a separate `EudiWallet` argument, not inside `EudiWalletConfiguration`. | Replace demo LoTE endpoints and fallback anchors with production trust anchors, and review `defaultPolicy` / `statusTrustPolicy` before go-live. |
 | `deviceAuthMethod` | Device authentication method used by WalletKit. | Current value is `.deviceSignature`; confirm with WalletKit and assurance policy. |
 | `uiCulture` | Locale passed to WalletKit. | Confirm supported locales and fallback behavior. |
 | `logFileName` | WalletKit log file name. | Disable or heavily redact production logs unless support policy requires a controlled log export. |
@@ -893,13 +898,16 @@ Production validation:
 * Confirm the extension appears and can authorize or deny the request.
 * Delete or revoke the document and confirm registration is removed or no longer usable.
 
-## Reader Trust Store
+## Trust Store
 
-Current code loads DER certificates by resource name:
+Trust is configured through `WalletKitConfig.trustConfiguration`, which is passed to `EudiWallet` as
+the `trustConfig` argument. The primary trust source is an ETSI LoTE (List of Trusted Entities)
+source that fetches signed trusted lists at runtime; a static list of bundled DER certificates is
+configured as the `fallbackTrustSource`. The fallback certificates are loaded by resource name:
 
 ```swift
-var trustedReaderRootCertificates: [x5chain] {
-  let certificates = [
+var staticRootCertificates: [Data] {
+  [
     "pidissuerca02_cz",
     "pidissuerca02_ee",
     "pidissuerca02_eu",
@@ -908,16 +916,15 @@ var trustedReaderRootCertificates: [x5chain] {
     "pidissuerca02_pt",
     "pidissuerca02_ut",
     "r45_staging"
-  ]
-  return certificates
-    .compactMap { loadCertificate($0) }
-    .map { [$0] }
+  ].compactMap { loadCertificate($0) }
 }
 ```
 
 Production guidance:
 
-* Remove demo and staging trust anchors that are not part of the production trust framework.
+* Replace the demo LoTE endpoints in `trustConfiguration` with your production trusted-list locations.
+* Review `defaultPolicy`, `requireSignedMetadata`, and `statusTrustPolicy` for production assurance.
+* Remove demo and staging fallback trust anchors that are not part of the production trust framework.
 * Add only production IACA, reader root, verifier, or scheme certificates approved for launch.
 * Use clear file names, for example `ms_iaca_2026.der`.
 * Document certificate owner, fingerprint, serial number, validity period, source, and rotation plan.

--- a/wiki/HOW_TO_BUILD.md
+++ b/wiki/HOW_TO_BUILD.md
@@ -169,11 +169,18 @@ var issuersConfig: [String: VciConfig] {
         .init(
           config: .init(
             credentialIssuerURL: "https://issuer.eudiw.dev",
-            clientId: "wallet-dev",
-            keyAttestationsConfig: .init(walletAttestationsProvider: walletKitAttestationProvider),
+            clientId: "eudiw-abca",
+            keyAttestationsConfig: .init(
+              walletAttestationsProvider: walletKitAttestationProvider,
+              popKeyOptions: KeyOptions(
+                secureAreaName: SecureEnclaveSecureArea.name,
+                accessControl: []
+              )
+            ),
             authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
             parUsage: .required(authorizationCodeDPoPBinding: true),
             requireDpop: true,
+            issuerMetadataPolicy: trustConfiguration.issuerMetadataPolicy,
             cacheIssuerMetadata: true
           ),
           order: 1
@@ -184,11 +191,18 @@ var issuersConfig: [String: VciConfig] {
         .init(
           config: .init(
             credentialIssuerURL: "https://ec.dev.issuer.eudiw.dev",
-            clientId: "wallet-dev",
-            keyAttestationsConfig: .init(walletAttestationsProvider: walletKitAttestationProvider),
+            clientId: "eudiw-abca",
+            keyAttestationsConfig: .init(
+              walletAttestationsProvider: walletKitAttestationProvider,
+              popKeyOptions: KeyOptions(
+                secureAreaName: SecureEnclaveSecureArea.name,
+                accessControl: []
+              )
+            ),
             authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
             parUsage: .required(authorizationCodeDPoPBinding: true),
             requireDpop: true,
+            issuerMetadataPolicy: trustConfiguration.issuerMetadataPolicy,
             cacheIssuerMetadata: true
           ),
           order: 1
@@ -201,7 +215,7 @@ var issuersConfig: [String: VciConfig] {
 }
 ```
 
-In this example, the `issuersConfig` property dynamically assigns configurations, such as `credentialIssuerURL`, `clientId`, `authFlowRedirectionURI`, `parUsage`, `requireDpop`, `keyAttestationsConfig`, and `cacheIssuerMetadata`, based on the current `appBuildVariant`. This ensures that the appropriate settings are applied for each variant (e.g., `.DEMO` or `.DEV`). The snippet is trimmed to one issuer per variant for brevity; the live `WalletKitConfigImpl` returns **two** issuers per variant — the primary (`order: 1`) plus a backend issuer (`order: 0`): `https://issuer-backend.eudiw.dev` for `.DEMO` and `https://dev.issuer-backend.eudiw.dev` for `.DEV`.
+In this example, the `issuersConfig` property dynamically assigns configurations, such as `credentialIssuerURL`, `clientId`, `authFlowRedirectionURI`, `parUsage`, `requireDpop`, `keyAttestationsConfig`, `issuerMetadataPolicy` (derived from `trustConfiguration`), and `cacheIssuerMetadata`, based on the current `appBuildVariant`. This ensures that the appropriate settings are applied for each variant (e.g., `.DEMO` or `.DEV`). The snippet is trimmed to one issuer per variant for brevity; the live `WalletKitConfigImpl` returns **two** issuers per variant — the primary (`order: 1`) plus a backend issuer (`order: 0`): `https://issuer-backend.eudiw.dev` for `.DEMO` and `https://dev.issuer-backend.eudiw.dev` for `.DEV`.
 
 ### Running with local services
 


### PR DESCRIPTION
## Type of change

Dependencies: WalletKit 0.34.4 → 0.37.3, ISO18013 data-transfer/security/data-model to 0.23.x, wallet-storage 0.23.1, OpenID4VCI 0.50.0, plus the new EudiEtsi1196x2 trust library
Trust config migration: replace trustedReaderRootCertificates with the new TrustConfiguration (ETSI LoTE trusted-list source + static bundled-cert fallback, trust policies), passed to EudiWallet as trustConfig
Untrusted issuer/verifier UX: new TrustBlockedSheetContent bottom sheet; issuance flows (Add/Offer/Code) surface .issuerNotTrusted and presentation/proximity flows surface .notSecuredRequest, mapped via a new Error.isIssuerNotTrusted helper
VCI config: updated clientId, added popKeyOptions (Secure Enclave) and issuerMetadataPolicy derived from the trust configuration
Docs: updated CONFIGURATION.md, GO_LIVE.md, and HOW_TO_BUILD.md to reflect the new trust API and VCI config
Tests: added coverage for Error.isIssuerNotTrusted and the issuer/verifier trust-failure branches in the AddDocument, DocumentOffer, Proximity, and Presentation interactors

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [x] Added Tests ()

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
