### PR TITLE
UI presentation history fixes

### DIFF
--- a/Modules/feature-common/Sources/UI/Request/BaseRequestViewModel.swift
+++ b/Modules/feature-common/Sources/UI/Request/BaseRequestViewModel.swift
@@ -255,7 +255,14 @@ open class BaseRequestViewModel<Router: RouterHost>: ViewModel<Router, RequestVi
   open func stopPresentation() async {}
   public func onVerifierNotTrusted() {
     setState {
-      $0.copy(isLoading: false, initialized: true).copy(error: nil)
+      $0.copy(
+        isLoading: false,
+        showMissingCredentials: false,
+        items: [],
+        combinations: [],
+        allowShare: false,
+        initialized: true
+      ).copy(error: nil)
     }
     isVerifierNotTrustedSheetShowing = true
     Task { await stopPresentation() }
@@ -270,8 +277,6 @@ open class BaseRequestViewModel<Router: RouterHost>: ViewModel<Router, RequestVi
     await onCombinationItemClick(combinationIndex: viewState.selectedCombinationIndex, id: id)
   }
 
-  /// Handles a row tap (expand/collapse or checkbox toggle) within a specific combination.
-  /// Edits that combination's data and, when it is the selected one, keeps `items` in sync.
   func onCombinationItemClick(combinationIndex: Int, id: String) async {
     guard viewState.combinations.indices.contains(combinationIndex) else { return }
 

--- a/Modules/feature-dashboard/Sources/UI/Dashboard/Tab/Transaction/TransactionTabView.swift
+++ b/Modules/feature-dashboard/Sources/UI/Dashboard/Tab/Transaction/TransactionTabView.swift
@@ -92,8 +92,8 @@ private struct TransactionTabViewContainer: View {
             ForEach(
               state.transactions.keys.sorted(by: {
                 state.sortIsDescending
-                ? $0.order < $1.order
-                : $0.order > $1.order
+                ? $0.order > $1.order
+                : $0.order < $1.order
               }),
               id: \.self
             ) { category in


### PR DESCRIPTION
## Type of change

Fix random attestation shown behind untrusted-verifier blocking sheet
Fix History tab section ordering putting oldest group on top

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
