### PR TITLE
Fix attestations persisting after clean install

### DIFF
--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "bdd143c859c213c9041c47fb53d8009d1f33e0b9",
-        "version" : "0.50.0"
+        "revision" : "935e4aaf7710e75196a35a38e83261a83a5dd446",
+        "version" : "0.51.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "c5ecc2dc89d713fd212014a37970c37b8be73699",
-        "version" : "0.37.3"
+        "revision" : "60ab2acb4d2a52ff5861f91773806f49b2424b3f",
+        "version" : "0.37.5"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "3abd8e54a0576d4114b78672e03c22d3613b5044",
-        "version" : "0.23.1"
+        "revision" : "5fc8442563b6502a01e8e30bde7b9700fdbf63c5",
+        "version" : "0.23.2"
       }
     },
     {

--- a/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
@@ -3607,6 +3607,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -3772,9 +3773,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -3845,10 +3846,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -3951,10 +3952,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -3995,8 +3996,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -6749,11 +6750,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -7180,10 +7182,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -7585,7 +7587,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -8000,7 +8002,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
+++ b/Modules/feature-dashboard/Sources/Interactor/Detail/DocumentDetailsInteractor.swift
@@ -94,7 +94,7 @@ final actor DocumentDetailsInteractorImpl: DocumentDetailsInteractor {
     do {
 
       if await shouldDeleteAllDocuments(type: type) {
-        await walletController.clearAllDocuments()
+        try await walletController.clearAllDocuments()
         successState = .success(shouldReboot: true)
       } else {
         try await walletController.deleteDocument(with: documentId, status: .issued)

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -6334,6 +6334,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -6500,9 +6501,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -6573,10 +6574,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -6679,10 +6680,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -6723,8 +6724,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -9509,11 +9510,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -9940,10 +9942,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -10345,7 +10347,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -10760,7 +10762,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
@@ -4241,6 +4241,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -4407,9 +4408,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -4480,10 +4481,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -4586,10 +4587,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -4630,8 +4631,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -7416,11 +7417,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -7847,10 +7849,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -8252,7 +8254,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -8667,7 +8669,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -4072,6 +4072,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -4238,9 +4239,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -4311,10 +4312,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -4417,10 +4418,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -4461,8 +4462,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -7247,11 +7248,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -7678,10 +7680,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -8083,7 +8085,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -8498,7 +8500,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
@@ -4069,6 +4069,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -4235,9 +4236,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -4308,10 +4309,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -4414,10 +4415,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -4458,8 +4459,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -7244,11 +7245,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -7675,10 +7677,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -8080,7 +8082,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -8495,7 +8497,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/Modules/feature-startup/Sources/Interactor/StartupInteractor.swift
+++ b/Modules/feature-startup/Sources/Interactor/StartupInteractor.swift
@@ -83,9 +83,11 @@ final actor StartupInteractorImpl: StartupInteractor {
   }
 
   private func manageStorageForFirstRun() async {
-    if !prefsController.getBool(forKey: .runAtLeastOnce) {
-      await walletKitController.clearAllDocuments()
-      keyChainController.clear()
+    guard !prefsController.getBool(forKey: .runAtLeastOnce) else { return }
+    try? await walletKitController.clearAllDocuments()
+
+    let didWipeStorage = keyChainController.clear()
+    if didWipeStorage {
       prefsController.setValue(true, forKey: .runAtLeastOnce)
     }
   }

--- a/Modules/feature-startup/Tests/Interactor/TestStartupInteractor.swift
+++ b/Modules/feature-startup/Tests/Interactor/TestStartupInteractor.swift
@@ -217,9 +217,9 @@ private extension TestStartupInteractor {
     }
   }
   
-  func stubKeyChainClear() {
+  func stubKeyChainClear(success: Bool = true) {
     stub(keyChainController) { mock in
-      when(mock.clear()).thenDoNothing()
+      when(mock.clear()).thenReturn(success)
     }
   }
   

--- a/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
@@ -3787,6 +3787,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -3953,9 +3954,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -4026,10 +4027,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -4132,10 +4133,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -4176,8 +4177,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -6962,11 +6963,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -7393,10 +7395,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -7798,7 +7800,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -8213,7 +8215,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/Modules/logic-api/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-api/Tests/Mock/GeneratedMocks.swift
@@ -1257,6 +1257,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_business
 @testable import logic_analytics
@@ -1418,9 +1419,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -1491,10 +1492,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -1597,10 +1598,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -1641,8 +1642,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
@@ -1558,6 +1558,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -1720,9 +1721,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -1793,10 +1794,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -1899,10 +1900,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -1943,8 +1944,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -4602,11 +4603,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -5033,10 +5035,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -5438,7 +5440,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -5853,7 +5855,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/Modules/logic-business/Sources/Controller/KeyChainController.swift
+++ b/Modules/logic-business/Sources/Controller/KeyChainController.swift
@@ -14,6 +14,7 @@
  * governing permissions and limitations under the Licence.
  */
 import Foundation
+import Security
 @preconcurrency import KeychainAccess
 
 public protocol KeyChainWrapper {
@@ -28,7 +29,7 @@ public protocol KeyChainController: Sendable {
   func removeObject(key: KeyChainWrapper)
   func validateKeyChainBiometry() throws
   func clearKeyChainBiometry()
-  func clear()
+  @discardableResult func clear() -> Bool
 }
 
 final class KeyChainControllerImpl: KeyChainController {
@@ -77,12 +78,27 @@ final class KeyChainControllerImpl: KeyChainController {
     try? self.keyChain.remove(self.biometryKey)
   }
 
-  public func clear() {
+  @discardableResult
+  public func clear() -> Bool {
     try? keyChain.removeAll()
+    return clearDocumentStorage()
   }
 }
 
 private extension KeyChainControllerImpl {
+  func clearDocumentStorage() -> Bool {
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecUseDataProtectionKeychain as String: true
+    ]
+    let accessGroup = configLogic.keyChainConfig.keychainAccessGroup
+    if !accessGroup.isEmpty {
+      query[kSecAttrAccessGroup as String] = accessGroup
+    }
+    let status = SecItemDelete(query as CFDictionary)
+    return status == errSecSuccess || status == errSecItemNotFound
+  }
+
   func setBiometricKey() throws {
     try self.keyChain
       .accessibility(

--- a/Modules/logic-business/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-business/Tests/Mock/GeneratedMocks.swift
@@ -237,6 +237,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_business
 
@@ -396,9 +397,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -469,10 +470,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -575,10 +576,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -619,8 +620,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.37.3"
+      exact: "0.37.5"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Sources/Controller/WalletKitController.swift
+++ b/Modules/logic-core/Sources/Controller/WalletKitController.swift
@@ -42,7 +42,7 @@ public protocol WalletKitController: Sendable {
   func fetchMainPidDocument() async -> (any DocClaimsDecodable)?
   func fetchDocument(with id: String) async -> (any DocClaimsDecodable)?
   func fetchDocuments(with ids: [String]) async -> [any DocClaimsDecodable]
-  func clearAllDocuments() async
+  func clearAllDocuments() async throws
   func deleteDocument(with id: String, status: DocumentStatus) async throws
   func loadDocuments() async throws
   func issueDocuments(
@@ -195,8 +195,9 @@ final actor WalletKitControllerImpl: WalletKitController {
     )
   }
 
-  func clearAllDocuments() async {
-    try? await wallet.deleteAllDocuments()
+  func clearAllDocuments() async throws {
+    try await wallet.deleteAllDocuments()
+
     try? await removeAllRegistration(
       with: wallet.loadAllDocuments()?.compactMap { return $0.id }
     )

--- a/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
@@ -636,6 +636,7 @@ import Cuckoo
 
 import Cuckoo
 import Foundation
+import Security
 import KeychainAccess
 @testable import logic_core
 @testable import logic_business
@@ -798,9 +799,9 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         )
     }
 
-    public func clear() {
+    public func clear() -> Bool {
         return cuckoo_manager.call(
-            "clear()",
+            "clear() -> Bool",
             parameters: (),
             escapingParameters: (),
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
@@ -871,10 +872,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
             ))
         }
         
-        func clear() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clear() -> Cuckoo.ProtocolStubFunction<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockKeyChainController.self,
-                method: "clear()",
+                method: "clear() -> Bool",
                 parameterMatchers: matchers
             ))
         }
@@ -977,10 +978,10 @@ public class MockKeyChainController: KeyChainController, Cuckoo.ProtocolMock, @u
         
         
         @discardableResult
-        func clear() -> Cuckoo.__DoNotUse<(), Void> {
+        func clear() -> Cuckoo.__DoNotUse<(), Bool> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clear()",
+                "clear() -> Bool",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -1021,8 +1022,8 @@ public class KeyChainControllerStub:KeyChainController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     
-    public func clear() {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    public func clear() -> Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
 }
 
@@ -3680,11 +3681,12 @@ public class MockWalletKitController: WalletKitController, Cuckoo.ProtocolMock, 
         )
     }
 
-    public func clearAllDocuments() async {
-        return await cuckoo_manager.call(
-            "clearAllDocuments() async",
+    public func clearAllDocuments() async throws {
+        return try await cuckoo_manager.callThrows(
+            "clearAllDocuments() async throws",
             parameters: (),
             escapingParameters: (),
+            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: await __defaultImplStub!.clearAllDocuments()
         )
@@ -4111,10 +4113,10 @@ return await cuckoo_manager.call(
             ))
         }
         
-        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+        func clearAllDocuments() -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(),Swift.Error> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockWalletKitController.self,
-                method: "clearAllDocuments() async",
+                method: "clearAllDocuments() async throws",
                 parameterMatchers: matchers
             ))
         }
@@ -4516,7 +4518,7 @@ return await cuckoo_manager.call(
         func clearAllDocuments() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-                "clearAllDocuments() async",
+                "clearAllDocuments() async throws",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -4931,7 +4933,7 @@ public class WalletKitControllerStub:WalletKitController, @unchecked Sendable {
         return DefaultValueRegistry.defaultValue(for: ([any DocClaimsDecodable]).self)
     }
     
-    public func clearAllDocuments() async {
+    public func clearAllDocuments() async throws {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     


### PR DESCRIPTION
## Type of change

Wipe wallet-kit keychain items on first run. iOS keeps keychain data across uninstall, and wallet-kit stores document/key items as generic-password items under composed service values (<service>:<type>:<status>) that keyChain.removeAll() never matched — so attestations persisted after a clean install. Added clearDocumentStorage() to delete every generic-password item in the wallet's access group.
Bump wallet-kit 0.37.3 → 0.37.5 (openid4vci 0.50.0 → 0.51.0, wallet-storage 0.23.1 → 0.23.2), which also fixes mDL rotating-batch credential instances (multi-option reuse policy now parses → full batch issued and displayed as N/N

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
