### PR TITLE
Reconcile document registrations after every storage change

### DIFF
--- a/EudiReferenceWallet.xcodeproj/project.pbxproj
+++ b/EudiReferenceWallet.xcodeproj/project.pbxproj
@@ -1295,7 +1295,7 @@
 			repositoryURL = "https://github.com/eu-digital-identity-wallet/av-lib-ios-w3c-dc-api.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.21.0;
+				version = 0.25.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "05db2877bbf687e0f0579c50d52194d23974b0ab228e8d2f82521c23d0ac2336",
+  "originHash" : "d4d3cf68b1405f5666a1769a0b6b5c24511c3cf4b3c6fe4a9409c87a55e7cfa1",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/av-lib-ios-w3c-dc-api.git",
       "state" : {
-        "revision" : "567ae47b54f2b5a6fd1e0610afe17e4901b00a8d",
-        "version" : "0.21.0"
+        "revision" : "e0500debbddcc7a4528296ac60b6a9866b7ef558",
+        "version" : "0.25.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "6d3424611604ccb67b993739b42e41e871a5ed80",
-        "version" : "0.24.1"
+        "revision" : "2bc9318fe4b8365ac50a19f4c724b375f21374b6",
+        "version" : "0.25.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-transfer.git",
       "state" : {
-        "revision" : "e38cd1b4ba88bfb3212deed5b2daf606dbc4e6dd",
-        "version" : "0.24.3"
+        "revision" : "9a593f3c88bee78c8812fac0c4748c3331bc9362",
+        "version" : "0.25.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "c2d8ad046fcf7745dbcde98adf22033651bcbc5e",
-        "version" : "0.24.6"
+        "revision" : "72b3b4864665616b9537ae1f2e142e620c3a920d",
+        "version" : "0.25.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "37c712ee275a3c01ca6423aaeb0a82288f575828",
-        "version" : "0.53.1"
+        "revision" : "c2f29c93ce813eeb225f1dce54aad50ed9b3ddf2",
+        "version" : "0.53.2"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "7e25d379856e21dab24411b2ae428ad166af407a",
-        "version" : "0.40.9"
+        "revision" : "d1c3afdedee0526acd3fd16eafdb9f972ed94ac8",
+        "version" : "0.50.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "5fc8442563b6502a01e8e30bde7b9700fdbf63c5",
-        "version" : "0.23.2"
+        "revision" : "a6017b0ce984261639564004e486ae7f1663c15d",
+        "version" : "0.25.0"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git",
       "state" : {
-        "revision" : "a3c4bd2c52e9f91ac45d720e728fb757c63f39fc",
-        "version" : "0.14.6"
+        "revision" : "0cc38aaab39bc41f61799e03322d0b7fdbb8705d",
+        "version" : "0.14.7"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/beatt83/jose-swift.git",
       "state" : {
-        "revision" : "b7d3ef55660fefd045641293bc95d4cdc07a15d8",
-        "version" : "6.0.4"
+        "revision" : "9b5fde623a083ef86291e9b1a1b8a4fe3084b29f",
+        "version" : "6.0.5"
       }
     },
     {
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GigaBitcoin/secp256k1.swift.git",
       "state" : {
-        "revision" : "4c77c7384768acf1093d66ccaacf298d322b10b7",
-        "version" : "0.15.0"
+        "revision" : "e70a10e036a55fffea31568f0af92d69b6d449cd",
+        "version" : "0.23.2"
       }
     },
     {
@@ -393,8 +393,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -413,15 +413,6 @@
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
-      }
-    },
-    {
-      "identity" : "swift-zlib",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/beatt83/swift-zlib.git",
-      "state" : {
-        "revision" : "8cf51bfdf81c46702dac496d16397d92ac392532",
-        "version" : "1.0.2"
       }
     },
     {
@@ -494,6 +485,15 @@
       "state" : {
         "revision" : "77ee0721798186f71b7ee8f7e29be8495d28360f",
         "version" : "9.9.0"
+      }
+    },
+    {
+      "identity" : "zlib",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DLTAStudio/zlib.git",
+      "state" : {
+        "revision" : "b68b56c8549c50777663b50a3b076d6589b19c58",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EudiReferenceWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d4d3cf68b1405f5666a1769a0b6b5c24511c3cf4b3c6fe4a9409c87a55e7cfa1",
+  "originHash" : "1a9232e16609bff378b47d33b928523182114c4f3170c24820a92549dee408e7",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
       "state" : {
-        "revision" : "d1c3afdedee0526acd3fd16eafdb9f972ed94ac8",
-        "version" : "0.50.0"
+        "revision" : "ca8802124a06e65f49903e8ebf35a427cc345fa5",
+        "version" : "0.51.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-storage.git",
       "state" : {
-        "revision" : "a6017b0ce984261639564004e486ae7f1663c15d",
-        "version" : "0.25.0"
+        "revision" : "08da13e71e902683b1f16bd6ecf22d4557ca9e91",
+        "version" : "0.26.0"
       }
     },
     {

--- a/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-common/Tests/Mock/GeneratedMocks.swift
@@ -9382,25 +9382,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -9411,18 +9399,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -9441,22 +9421,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -9469,11 +9437,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }

--- a/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-dashboard/Tests/Mock/GeneratedMocks.swift
@@ -12218,25 +12218,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -12247,18 +12235,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -12277,22 +12257,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -12305,11 +12273,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }

--- a/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-issuance/Tests/Mock/GeneratedMocks.swift
@@ -10057,25 +10057,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -10086,18 +10074,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -10116,22 +10096,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -10144,11 +10112,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }

--- a/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-presentation/Tests/Mock/GeneratedMocks.swift
@@ -9922,25 +9922,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -9951,18 +9939,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -9981,22 +9961,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -10009,11 +9977,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }

--- a/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-proximity/Tests/Mock/GeneratedMocks.swift
@@ -9919,25 +9919,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -9948,18 +9936,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -9978,22 +9958,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -10006,11 +9974,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }

--- a/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/feature-startup/Tests/Mock/GeneratedMocks.swift
@@ -9603,25 +9603,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -9632,18 +9620,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -9662,22 +9642,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -9690,11 +9658,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }

--- a/Modules/feature-test/Sources/Utils/Constants.swift
+++ b/Modules/feature-test/Sources/Utils/Constants.swift
@@ -206,7 +206,7 @@ extension Constants {
 
 extension Constants {
   struct MockPresentationService: PresentationService {
-    func sendResponse(userAccepted: Bool, itemsToSend: EudiWalletKit.RequestItems, deviceNameSpacesToSend: MdocDataTransfer18013.RequestDeviceNameSpaces?, onSuccess: (@Sendable (URL?) -> Void)?) async throws {}
+    func sendResponse(userAccepted: Bool, itemsToSend: EudiWalletKit.RequestItems, deviceNameSpacesToSend: MdocDataTransfer18013.RequestDeviceNameSpaces?, authenticationContext: ThreadSafeAuthContext, onSuccess: (@Sendable (URL?) -> Void)?) async throws {}
 
     var zkpDocumentIds: [WalletStorage.Document.ID]?
 
@@ -307,7 +307,8 @@ extension Constants {
     storageManager: .init(storageService: mockStorageService),
     docIdToPresentInfo: [:],
     documentKeyIndexes: [:],
-    userAuthenticationRequired: false
+    userAuthenticationRequired: false,
+    localAuthenticationContext: ThreadSafeAuthContext()
   )
 }
 

--- a/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-authentication/Tests/Mock/GeneratedMocks.swift
@@ -7200,25 +7200,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -7229,18 +7217,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -7259,22 +7239,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -7287,11 +7255,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.40.9"
+      exact: "0.50.0"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Package.swift
+++ b/Modules/logic-core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit.git",
-      exact: "0.50.0"
+      exact: "0.51.0"
     ),
     .package(
       name: "logic-resources",

--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -110,7 +110,7 @@ struct WalletKitConfigImpl: WalletKitConfig {
     KeyOptions(
       curve: .P256,
       secureAreaName: SecureEnclaveSecureArea.name,
-      accessControl: []
+      accessControl: .empty
     )
   }
 
@@ -132,7 +132,7 @@ struct WalletKitConfigImpl: WalletKitConfig {
                 walletAttestationsProvider: walletKitAttestationProvider,
                 popKeyOptions: KeyOptions(
                   secureAreaName: SecureEnclaveSecureArea.name,
-                  accessControl: []
+                  accessControl: .empty
                 )
               ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
@@ -152,7 +152,7 @@ struct WalletKitConfigImpl: WalletKitConfig {
                 walletAttestationsProvider: walletKitAttestationProvider,
                 popKeyOptions: KeyOptions(
                   secureAreaName: SecureEnclaveSecureArea.name,
-                  accessControl: []
+                  accessControl: .empty
                 )
               ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
@@ -175,7 +175,7 @@ struct WalletKitConfigImpl: WalletKitConfig {
                 walletAttestationsProvider: walletKitAttestationProvider,
                 popKeyOptions: KeyOptions(
                   secureAreaName: SecureEnclaveSecureArea.name,
-                  accessControl: []
+                  accessControl: .empty
                 )
               ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,
@@ -195,7 +195,7 @@ struct WalletKitConfigImpl: WalletKitConfig {
                 walletAttestationsProvider: walletKitAttestationProvider,
                 popKeyOptions: KeyOptions(
                   secureAreaName: SecureEnclaveSecureArea.name,
-                  accessControl: []
+                  accessControl: .empty
                 )
               ),
               authFlowRedirectionURI: URL(string: "eu.europa.ec.euidi://authorization")!,

--- a/Modules/logic-core/Sources/Controller/WalletKitController.swift
+++ b/Modules/logic-core/Sources/Controller/WalletKitController.swift
@@ -216,19 +216,18 @@ final actor WalletKitControllerImpl: WalletKitController {
 
   func clearAllDocuments() async throws {
     try await wallet.deleteAllDocuments()
-
-    try? await removeAllRegistration(
-      with: wallet.loadAllDocuments()?.compactMap { return $0.id }
-    )
+    await reconcileRegistrations()
   }
 
   func deleteDocument(with id: String, status: DocumentStatus) async throws {
     try await wallet.deleteDocument(id: id, status: status)
     try await revokedDocumentStorageController.delete(id)
+    await reconcileRegistrations()
   }
 
   func loadDocuments() async throws {
     _ = try await wallet.loadAllDocuments()
+    await reconcileRegistrations()
   }
 
   func startProximityPresentation() async -> ProximitySessionCoordinator {
@@ -289,9 +288,9 @@ final actor WalletKitControllerImpl: WalletKitController {
     wallet.storage.getDocumentModel(id: id)
   }
 
-  func fetchDocuments(with ids: [String]) -> [any DocClaimsDecodable] {
+  func fetchDocuments(with ids: [String]) async -> [any DocClaimsDecodable] {
     let documents = fetchIssuedDocuments().filter { ids.contains($0.id) }
-    registerForDocumentIdentityExtension(documents: documents)
+    await reconcileRegistrations()
     return documents
   }
 
@@ -374,6 +373,7 @@ final actor WalletKitControllerImpl: WalletKitController {
     guard let document = response.documents.first else {
       throw WalletCoreError.unableToIssueAndStore
     }
+    await reconcileRegistrations()
     return document
   }
 
@@ -396,6 +396,7 @@ final actor WalletKitControllerImpl: WalletKitController {
     if result.isDeferred {
       return result.transformToDeferredDecodable()
     } else if let doc = fetchDocument(with: result.id) {
+      await reconcileRegistrations()
       return doc
     } else {
       throw WalletCoreError.unableFetchDocument
@@ -433,13 +434,15 @@ final actor WalletKitControllerImpl: WalletKitController {
       documentId: pendingDoc.id,
       documentTypeIdentifier: pendingDoc.documentTypeIdentifier
     )
-    return try await wallet.resumePendingIssuance(
+    let document = try await wallet.resumePendingIssuance(
       issuerName: metadata.credentialIssuerIdentifier,
       pendingDoc: pendingDoc,
       webUrl: webUrl,
       credentialOptions: credentialOptions,
       keyOptions: walletKitConfig.keyOptions
     )
+    await reconcileRegistrations()
+    return document
   }
 
   func storeDynamicIssuancePendingUrl(with url: URL) {
@@ -714,32 +717,18 @@ final actor WalletKitControllerImpl: WalletKitController {
 
 private extension WalletKitControllerImpl {
 
-  func registerForDocumentIdentityExtension(documents: [any DocClaimsDecodable]) {
-    Task {
-      for document in documents {
-        do {
-          if #available(iOS 26.0, *), document.docDataFormat == .cbor {
-            try await documentRegistrationManager.addRegistration(
-              mobileDocumentType: document.docType,
-              supportedAuthorityKeyIdentifiers: [],
-              documentIdentifier: document.id,
-              invalidationDate: document.validUntil
-            )
-          }
-        } catch {
-          throw WalletCoreError.unableFetchDocuments
+  func reconcileRegistrations() async {
+    await documentRegistrationManager.reconcile(
+      desired: fetchIssuedDocuments()
+        .filter { $0.docDataFormat == .cbor }
+        .map {
+          RegistrationDescriptor(
+            documentIdentifier: $0.id,
+            mobileDocumentType: $0.docType,
+            invalidationDate: $0.validUntil
+          )
         }
-      }
-    }
-  }
-
-  func removeAllRegistration(with ids: [String]?) async {
-    if #available(iOS 26.0, *) {
-      guard let ids else { return }
-      do {
-        try await documentRegistrationManager.removeRegistration(documentIdentifiers: ids)
-      } catch {}
-    } else {}
+    )
   }
 
   func decodeDeeplink(link: URLComponents) -> String? {

--- a/Modules/logic-core/Sources/DocumentRegistrationManager/DocumentRegistrationManager.swift
+++ b/Modules/logic-core/Sources/DocumentRegistrationManager/DocumentRegistrationManager.swift
@@ -16,16 +16,25 @@
 import Foundation
 import IdentityDocumentServices
 
-public protocol DocumentRegistrationManager: Sendable {
-  func addRegistration(
-    mobileDocumentType: String,
-    supportedAuthorityKeyIdentifiers: [Data],
+public struct RegistrationDescriptor: Sendable, Equatable {
+
+  public let documentIdentifier: String
+  public let mobileDocumentType: String
+  public let invalidationDate: Date?
+
+  public init(
     documentIdentifier: String,
+    mobileDocumentType: String,
     invalidationDate: Date?
-  ) async throws
-  func removeRegistration(
-    documentIdentifiers: [String]
-  ) async throws
+  ) {
+    self.documentIdentifier = documentIdentifier
+    self.mobileDocumentType = mobileDocumentType
+    self.invalidationDate = invalidationDate
+  }
+}
+
+public protocol DocumentRegistrationManager: Sendable {
+  func reconcile(desired: [RegistrationDescriptor]) async
 }
 
 @available(iOS 26.0, *)
@@ -38,35 +47,46 @@ final actor DocumentRegistrationManagerImpl: DocumentRegistrationManager {
     IdentityDocumentProviderRegistrationStore()
   }
 
-  func addRegistration(
-    mobileDocumentType: String,
-    supportedAuthorityKeyIdentifiers: [Data],
-    documentIdentifier: String,
-    invalidationDate: Date?
-  ) async throws {
+  func reconcile(desired: [RegistrationDescriptor]) async {
 
     let store = makeStore()
 
-    let registration = MobileDocumentRegistration(
-      mobileDocumentType: mobileDocumentType,
-      supportedAuthorityKeyIdentifiers: supportedAuthorityKeyIdentifiers,
-      documentIdentifier: documentIdentifier,
-      invalidationDate: invalidationDate
-    )
+    guard await store.status == .authorized else { return }
+    guard let current = try? await store.registrations else { return }
 
-    try await store.addRegistration(registration)
-  }
-
-  func removeRegistration(
-    documentIdentifiers: [String]
-  ) async throws {
-
-    let store = makeStore()
-    for documentIdentifier in documentIdentifiers {
-      try await store.removeRegistration(
-        forDocumentIdentifier: documentIdentifier
+    let desiredIdentifiers = Set(desired.map { $0.documentIdentifier })
+    for registration in current where !desiredIdentifiers.contains(registration.documentIdentifier) {
+      try? await store.removeRegistration(
+        forDocumentIdentifier: registration.documentIdentifier
       )
     }
+
+    let registered = Dictionary(
+      current
+        .compactMap { $0 as? MobileDocumentRegistration }
+        .map { ($0.documentIdentifier, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
+
+    for descriptor in desired where needsWrite(descriptor, registered: registered[descriptor.documentIdentifier]) {
+      try? await store.addRegistration(
+        MobileDocumentRegistration(
+          mobileDocumentType: descriptor.mobileDocumentType,
+          supportedAuthorityKeyIdentifiers: [],
+          documentIdentifier: descriptor.documentIdentifier,
+          invalidationDate: descriptor.invalidationDate
+        )
+      )
+    }
+  }
+
+  private func needsWrite(
+    _ descriptor: RegistrationDescriptor,
+    registered: MobileDocumentRegistration?
+  ) -> Bool {
+    guard let registered else { return true }
+    return registered.mobileDocumentType != descriptor.mobileDocumentType
+    || registered.invalidationDate != descriptor.invalidationDate
   }
 }
 

--- a/Modules/logic-core/Sources/DocumentRegistrationManager/DocumentRegistrationManagerNoOp.swift
+++ b/Modules/logic-core/Sources/DocumentRegistrationManager/DocumentRegistrationManagerNoOp.swift
@@ -20,18 +20,7 @@ final class DocumentRegistrationManagerNoOp: DocumentRegistrationManager, Sendab
 
   init() {}
 
-  func addRegistration(
-    mobileDocumentType: String,
-    supportedAuthorityKeyIdentifiers: [Data],
-    documentIdentifier: String,
-    invalidationDate: Date?
-  ) async throws {
-    // No-op: Identity Document Services not available on this iOS version
-  }
-
-  func removeRegistration(
-    documentIdentifiers: [String]
-  ) async throws {
+  func reconcile(desired: [RegistrationDescriptor]) async {
     // No-op: Identity Document Services not available on this iOS version
   }
 }

--- a/Modules/logic-ui/Tests/Controller/TestDeepLinkController.swift
+++ b/Modules/logic-ui/Tests/Controller/TestDeepLinkController.swift
@@ -559,7 +559,7 @@ private extension TestDeepLinkController {
     
     var flow: EudiWalletKit.FlowType
 
-    func sendResponse(userAccepted: Bool, itemsToSend: EudiWalletKit.RequestItems, deviceNameSpacesToSend: MdocDataTransfer18013.RequestDeviceNameSpaces?, onSuccess: (@Sendable (URL?) -> Void)?) async throws {}
+    func sendResponse(userAccepted: Bool, itemsToSend: EudiWalletKit.RequestItems, deviceNameSpacesToSend: MdocDataTransfer18013.RequestDeviceNameSpaces?, authenticationContext: ThreadSafeAuthContext, onSuccess: (@Sendable (URL?) -> Void)?) async throws {}
   }
   
   static let mockTransactionLog: TransactionLog = .init(
@@ -583,6 +583,7 @@ private extension TestDeepLinkController {
     storageManager: .init(storageService: mockStorageService),
     docIdToPresentInfo: [:],
     documentKeyIndexes: [:],
-    userAuthenticationRequired: false
+    userAuthenticationRequired: false,
+    localAuthenticationContext: ThreadSafeAuthContext()
   )
 }

--- a/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
+++ b/Modules/logic-ui/Tests/Mock/GeneratedMocks.swift
@@ -6278,25 +6278,13 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
     }
 
 
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return try await cuckoo_manager.callThrows(
-            "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-            parameters: (p0, p1, p2, p3),
-            escapingParameters: (p0, p1, p2, p3),
-            errorType: Swift.Error.self,
-            superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.addRegistration(mobileDocumentType: p0, supportedAuthorityKeyIdentifiers: p1, documentIdentifier: p2, invalidationDate: p3)
-        )
-    }
-
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
-        return try await cuckoo_manager.callThrows(
-            "removeRegistration(documentIdentifiers p0: [String]) async throws",
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
+        return await cuckoo_manager.call(
+            "reconcile(desired p0: [RegistrationDescriptor]) async",
             parameters: (p0),
             escapingParameters: (p0),
-            errorType: Swift.Error.self,
             superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
-            defaultCall: await __defaultImplStub!.removeRegistration(documentIdentifiers: p0)
+            defaultCall: await __defaultImplStub!.reconcile(desired: p0)
         )
     }
 
@@ -6307,18 +6295,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
             self.cuckoo_manager = manager
         }
         
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<(String, [Data], String, Date?),Swift.Error> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.ProtocolStubNoReturnFunction<([RegistrationDescriptor])> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                parameterMatchers: matchers
-            ))
-        }
-        
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.ProtocolStubNoReturnThrowingFunction<([String]),Swift.Error> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockDocumentRegistrationManager.self,
-                method: "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                method: "reconcile(desired p0: [RegistrationDescriptor]) async",
                 parameterMatchers: matchers
             ))
         }
@@ -6337,22 +6317,10 @@ public class MockDocumentRegistrationManager: DocumentRegistrationManager, Cucko
         
         
         @discardableResult
-        func addRegistration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.OptionalMatchable>(mobileDocumentType p0: M1, supportedAuthorityKeyIdentifiers p1: M2, documentIdentifier p2: M3, invalidationDate p3: M4) -> Cuckoo.__DoNotUse<(String, [Data], String, Date?), Void> where M1.MatchedType == String, M2.MatchedType == [Data], M3.MatchedType == String, M4.OptionalMatchedType == Date {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [Data], String, Date?)>] = [wrap(matchable: p0) { $0.0 }, wrap(matchable: p1) { $0.1 }, wrap(matchable: p2) { $0.2 }, wrap(matchable: p3) { $0.3 }]
+        func reconcile<M1: Cuckoo.Matchable>(desired p0: M1) -> Cuckoo.__DoNotUse<([RegistrationDescriptor]), Void> where M1.MatchedType == [RegistrationDescriptor] {
+            let matchers: [Cuckoo.ParameterMatcher<([RegistrationDescriptor])>] = [wrap(matchable: p0) { $0 }]
             return cuckoo_manager.verify(
-                "addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws",
-                callMatcher: callMatcher,
-                parameterMatchers: matchers,
-                sourceLocation: sourceLocation
-            )
-        }
-        
-        
-        @discardableResult
-        func removeRegistration<M1: Cuckoo.Matchable>(documentIdentifiers p0: M1) -> Cuckoo.__DoNotUse<([String]), Void> where M1.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<([String])>] = [wrap(matchable: p0) { $0 }]
-            return cuckoo_manager.verify(
-                "removeRegistration(documentIdentifiers p0: [String]) async throws",
+                "reconcile(desired p0: [RegistrationDescriptor]) async",
                 callMatcher: callMatcher,
                 parameterMatchers: matchers,
                 sourceLocation: sourceLocation
@@ -6365,11 +6333,7 @@ public class DocumentRegistrationManagerStub:DocumentRegistrationManager, @unche
 
 
     
-    public func addRegistration(mobileDocumentType p0: String, supportedAuthorityKeyIdentifiers p1: [Data], documentIdentifier p2: String, invalidationDate p3: Date?) async throws {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    public func removeRegistration(documentIdentifiers p0: [String]) async throws {
+    public func reconcile(desired p0: [RegistrationDescriptor]) async {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 }


### PR DESCRIPTION
## Type of change

Fixes #581.

Problem. Registrations with the system credential picker were maintained incrementally and never removed in practice. deleteDocument(with:status:) had no removal call at all. clearAllDocuments() built its identifier list from loadAllDocuments() after deleteAllDocuments() had already run, so it always passed an empty array — a removal path that removed nothing.

As the reporter measured on device, iOS accepts a registration whose documentIdentifier has no backing document, does not validate it at registration time, does not garbage collect it, and clears it only on an explicit removeRegistration(forDocumentIdentifier:). A document deleted in the app therefore stayed registered for the life of the install.

Change. addRegistration / removeRegistration are replaced by a single reconcile(desired:) on DocumentRegistrationManager. It reads the registration store, diffs it against the documents actually held, removes registrations with no backing document, and rewrites any whose document type or invalidation date no longer matches. RegistrationDescriptor keeps the protocol free of IdentityDocumentServices types so it stays usable below iOS 26.

The key property is that reconcile is convergent, not incremental: it diffs against the store itself rather than against our own bookkeeping, so a wrong state — including one left by an earlier build — is corrected on the next pass instead of persisting.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
